### PR TITLE
Format selector

### DIFF
--- a/webant/templates/opens_desc.xml
+++ b/webant/templates/opens_desc.xml
@@ -5,9 +5,9 @@
    <Tags>example web</Tags>
    <Contact>admin@example.com</Contact>
    <Url type="text/xml"
-        template="{{ request.scheme }}://{{request.host}}{{url_for('search',format='opensearch') |e }}&amp;q={searchTerms}"/>
+        template="{{ request.scheme }}://{{request.host}}{{url_for('search',format='application/opensearchdescription+xml') |e }}&amp;q={searchTerms}"/>
    <Url type="text/html" 
-        template="{{ request.scheme }}://{{request.host}}{{url_for('search',format='html') |e }}&amp;q={searchTerms}"/>
+        template="{{ request.scheme }}://{{request.host}}{{url_for('search',format='text/html') |e }}&amp;q={searchTerms}"/>
    <OutputEncoding>UTF-8</OutputEncoding>
    <InputEncoding>UTF-8</InputEncoding>
  </OpenSearchDescription>

--- a/webant/webant.py
+++ b/webant/webant.py
@@ -63,15 +63,14 @@ def create_app(configfile=None):
             src = b['_source']
             src['_id'] = b['_id']
             books.append(src)
-        format = request.args.get('format', 'html')
-        if format == 'html':
+        format = reuqestedFormat(['text/html','application/opensearchdescription+xml','opensearch'])
+        if format == 'text/html':
             return render_template('search.html', books=books, query=query)
-        if format == 'opensearch':
+        if format == 'application/opensearchdescription+xml' or\
+           format == 'opensearch':
             return Response(render_template('opens.xml',
                                             books=books, query=query),
                             mimetype='text/xml')
-
-        abort(400, "Wrong format")
 
     @app.route('/description.xml')
     def description():
@@ -113,7 +112,7 @@ def create_app(configfile=None):
         if 'format' in request.args:
             fieldFormat = request.args.get('format')
             if fieldFormat not in acceptedFormat:
-                raise ValueError("requested format not supported")
+                raise ValueError("requested format not supported: "+ fieldFormat)
             return fieldFormat
         else:
             return request.accept_mimetypes.best_match(acceptedFormat)

--- a/webant/webant.py
+++ b/webant/webant.py
@@ -94,6 +94,30 @@ def create_app(configfile=None):
     def get_locale():
      return request.accept_languages.best_match(['en','it','sq'])   
 
+    def reuqestedFormat(acceptedFormat):
+        """Return the response format requested by client
+
+        Client could specify requested format using:
+        (options are processed in this order)
+            - `format` field in http request
+            - `Accept` header in http request
+        Example:
+            chooseFormat(['text/html','application/json'])
+        Args:
+            acceptedFormat: list containing all the accepted format
+        Returns:
+            string: the user requested mime-type (if supported)
+        Raises:
+            ValueError: if user request a mime-type not supported
+        """
+        if 'format' in request.args:
+            fieldFormat = request.args.get('format')
+            if fieldFormat not in acceptedFormat:
+                raise ValueError("requested format not supported")
+            return fieldFormat
+        else:
+            return request.accept_mimetypes.best_match(acceptedFormat)
+
     return app
 
 def main():


### PR DESCRIPTION
### Changes:
added function to retrieve client requested format

	Client could specify requested format using:
        (options are processed in this order)
            - `format` field in http request
            - `Accept` header in http request

update search function in order to use 'requestedFormat()'
### Notes: 
Now the code better suite http standard

I would like to use this to implement 'recently_added' route #14 