### PR TITLE
searchbar implemented like macro and add to search results page

### DIFF
--- a/webant/templates/index.html
+++ b/webant/templates/index.html
@@ -1,5 +1,6 @@
 {% extends "bootstrap/base.html" %}
 {% import "bootstrap/fixes.html" as fixes %}
+{% import 'searchbar.html' as searchbar %}
 
 {% block title %}
 Libreant | Homepage
@@ -14,14 +15,6 @@ Libreant | Homepage
 <div class="container">
     <h1>Libreant <small>{%trans%}What do you want to read today?{%endtrans%}</small></h1>
 
-    <form action="{{ url_for('search') }}" role="form">
-        <div class="input-group">
-	        <input name="q" class="form-control" type="text"/>
-            <span class="input-group-btn">
-                <button type="submit" class="btn btn-primary">
-                    <span class="glyphicon glyphicon-search" aria-hidden="true"></span> {%trans%}Search{%endtrans%}</button>
-            </span>
-        </div>
-    </form>
+    {{ searchbar.searchbar() }}
 
 {% endblock content %}

--- a/webant/templates/search.html
+++ b/webant/templates/search.html
@@ -8,7 +8,7 @@ Libreant | {%trans%}Search{%endtrans%}: {{ query }}
 
 {% block navbar %}
 {% import 'navbar.html' as navbar %}
-{{navbar.navbar(search=True, search_query=query)}}
+{{navbar.navbar(search=False)}}
 {% endblock %}
 
 {% block styles %}

--- a/webant/templates/search.html
+++ b/webant/templates/search.html
@@ -1,5 +1,6 @@
 {% extends "bootstrap/base.html" %}
 {% import "bootstrap/fixes.html" as fixes %}
+{% import 'searchbar.html' as searchbar %}
 
 {% block title %}
 Libreant | {%trans%}Search{%endtrans%}: {{ query }}
@@ -17,6 +18,11 @@ Libreant | {%trans%}Search{%endtrans%}: {{ query }}
 
 {% block content %}
 <div class="container">
+    
+    {{ searchbar.searchbar(search_query=query) }}
+
+    <hr />
+    
     <hgroup class="mb20">
         <h1>{%trans%}Search results{%endtrans%}</h1>
         <h2 class="lead">{% trans num = books|length%}{{num}} result was found for{%pluralize%}{{num}} results were found for{% endtrans %} <strong>{{ query }}</strong></h2>

--- a/webant/templates/searchbar.html
+++ b/webant/templates/searchbar.html
@@ -1,0 +1,13 @@
+{% macro searchbar(search_query="") %}
+
+<form action="{{ url_for('search') }}" role="form">
+    <div class="input-group">
+        <input name="q" class="form-control" type="text" value="{{ search_query }}"/>
+        <span class="input-group-btn">
+            <button type="submit" class="btn btn-primary">
+            <span class="glyphicon glyphicon-search" aria-hidden="true"></span> {%trans%}Search{%endtrans%}</button>
+        </span>
+    </div>
+</form>
+{% endmacro %}
+


### PR DESCRIPTION
Related to #34.
I reimplemented the search bar as a macro like the Nabar to be able to include in pages as search.html
![screenshot from 2015-01-21 14 37 43](https://cloud.githubusercontent.com/assets/6986802/5837042/f6d8d110-a17b-11e4-9f9f-7f84dc24b928.png)
Perhaps now there are too many searchbar the page. 
Should we make it visible only on mobile devices?

p.s. my first pull request, I'm exited!