### PR TITLE
Handle exceptions incrementing download count #87

### DIFF
--- a/webant/webant.py
+++ b/webant/webant.py
@@ -202,7 +202,11 @@ def create_app():
             return renderErrorPage(message='element with id "{}" has no files attached'.format(bookid), httpCode=404)
         for i,file in enumerate(b['_source']['_files']):
             if file['sha1'] == fileid:
-                app.get_db().increment_download_count(bookid,i)
+                try:
+                    app.get_db().increment_download_count(bookid, i)
+                except:
+                    app.logger.warn("Cannot increment download count",
+                                    exc_info=1)
                 return send_file(app.fsdb.getFilePath(file['fsdb_id']),
                                   mimetype=file['mime'],
                                   attachment_filename=file['name'],


### PR DESCRIPTION
The bug happens when the option script.groovy.sandbox.enabled is false
in elasticsearch configuration.
This commit just avoid crashing when this happens.

How to reproduce it: ensure that line
`script.groovy.sandbox.enabled: false`
is present on your `/etc/elasticsearch/elasticsearch.yml`,
then just try to download a book.

With this commit, only a warning (and full traceback) will be printed. Without it, the application will crash, giving a 500 Internal Server Error, thus making it impossible to download the file.

This closes #87 