### PR TITLE
Add ES_HOSTS option. Allows more complex deploy

### DIFF
--- a/webant/webant.py
+++ b/webant/webant.py
@@ -25,6 +25,7 @@ class LibreantCoreApp(Flask):
             'PRESET_PATHS': [],  # defaultPreset should be loaded as default?
             'FSDB_PATH': "",
             'SECRET_KEY': 'really insecure, please change me!',
+            'ES_HOSTS': None,
             'ES_INDEXNAME': 'libreant'
         }
         defaults.update(conf)
@@ -42,7 +43,8 @@ class LibreantCoreApp(Flask):
 
     def get_db(self):
         if self._db is None:
-            db = DB(Elasticsearch(), index_name=self.config['ES_INDEXNAME'])
+            db = DB(Elasticsearch(hosts=self.config['ES_HOSTS']),
+                    index_name=self.config['ES_INDEXNAME'])
             db.setup_db()
             # deferring assignment is meant to avoid that we _first_ cache the
             # DB object, then the setup_db() fails. This will let us with a


### PR DESCRIPTION
**EDIT: moved to #104 because github sucks**

With this option you can use a remote elasticsearch backend easily.
Its default value will just use elasticsearch default (that is, `localhost:9200`).

closes #86

# Hints for testing

## If you have two box

* On BoxA run elasticsearch (as described in the [readme](https://github.com/insomnia-lab/libreant#dependencies))
*  On BoxB run `webant`. Without any option, every search will fail, because the default host is localhost. Running

```sh
WEBANT_ES_HOSTS=BoxA webant
```

should work

## if you have only one

* Run elasticsearch on your box  (as described in the [readme](https://github.com/insomnia-lab/libreant#dependencies))
* Run `WEBANT_ES_HOSTS=localhost webant`. It should work
* Run `WEBANT_ES_HOSTS=1.2.3.4 webant` should not work.
* Run `WEBANT_ES_HOSTS=192.168.1.10 webant` should work (where 192.168.1.10 is some sort of LAN ip you have)
* In /etc/elasticsearch/elasticsearch.yml , set `network.host: 127.0.0.1`
* Re-run `WEBANT_ES_HOSTS=192.168.1.10 webant`; it should not work anymore
* `webant` should work
