### PR TITLE
 Add ES_HOSTS option. Allows more complex deploy #95 

### DIFF
--- a/webant/webant.py
+++ b/webant/webant.py
@@ -1,16 +1,17 @@
-from flask import Flask, render_template, request, abort, Response, redirect, url_for, send_file
+import tempfile
+import logging
+import os
+
+from flask import Flask, render_template, request, abort, Response, redirect, url_for, send_file, make_response
 from werkzeug import secure_filename
 from utils import requestedFormat
 from flask_bootstrap import Bootstrap
 from elasticsearch import Elasticsearch, NotFoundError
+from elasticsearch import exceptions as es_exceptions
 from flask.ext.babel import Babel, gettext
 from presets import PresetManager
 from constants import isoLangs
 from fsdb import Fsdb
-
-import tempfile
-import logging
-import os
 
 from libreantdb import DB
 from agherant import agherant
@@ -216,9 +217,16 @@ def create_app():
         # no file found with the given digest
         return renderErrorPage(message='no file found with id "{}" on item "{}"'.format(fileid, bookid), httpCode=404)
 
+
     @app.babel.localeselector
     def get_locale():
         return request.accept_languages.best_match(['en', 'it', 'sq'])
+
+    @app.errorhandler(es_exceptions.ConnectionError)
+    def handle_elasticsearch_down(error):
+        rsp = make_response('DB connection error', 503)
+        app.logger.error("Error connecting to DB; check your configuration")
+        return rsp
 
     return app
 

--- a/webant/webant.py
+++ b/webant/webant.py
@@ -25,6 +25,7 @@ class LibreantCoreApp(Flask):
             'PRESET_PATHS': [],  # defaultPreset should be loaded as default?
             'FSDB_PATH': "",
             'SECRET_KEY': 'really insecure, please change me!',
+            'ES_HOSTS': None,
             'ES_INDEXNAME': 'libreant'
         }
         defaults.update(conf)
@@ -42,7 +43,8 @@ class LibreantCoreApp(Flask):
 
     def get_db(self):
         if self._db is None:
-            db = DB(Elasticsearch(), index_name=self.config['ES_INDEXNAME'])
+            db = DB(Elasticsearch(hosts=self.config['ES_HOSTS']),
+                    index_name=self.config['ES_INDEXNAME'])
             db.setup_db()
             # deferring assignment is meant to avoid that we _first_ cache the
             # DB object, then the setup_db() fails. This will let us with a


### PR DESCRIPTION
With this option you can use a remote elasticsearch backend easily.
Its default value will just use elasticsearch default (that is, `localhost:9200`).

closes #86

# Hints for testing

## If you have two box

* On BoxA run elasticsearch (as described in the [readme](https://github.com/insomnia-lab/libreant#dependencies))
*  On BoxB run `webant`. Without any option, every search will fail, because the default host is localhost. Running

```sh
WEBANT_ES_HOSTS=BoxA webant
```

should work

## if you have only one

* Run elasticsearch on your box  (as described in the [readme](https://github.com/insomnia-lab/libreant#dependencies))
* Run `WEBANT_ES_HOSTS=localhost webant`. It should work
* Run `WEBANT_ES_HOSTS=1.2.3.4 webant` should not work.
* Run `WEBANT_ES_HOSTS=192.168.1.10 webant` should work (where 192.168.1.10 is some sort of LAN ip you have)
* In /etc/elasticsearch/elasticsearch.yml , set `network.host: 127.0.0.1`
* Re-run `WEBANT_ES_HOSTS=192.168.1.10 webant`; it should not work anymore
* `webant` should work
