### PR TITLE
search page restyle

### DIFF
--- a/webant/static/item_list.css
+++ b/webant/static/item_list.css
@@ -41,3 +41,12 @@
     cursor: pointer;
     background-color: #F7F7F7;
 }
+
+.list-warning{
+    text-align: center;
+}
+.list-warning .alert{
+    display: inline-block;
+    margin: auto;
+    margin-top: 25px;
+}

--- a/webant/templates/recents.html
+++ b/webant/templates/recents.html
@@ -17,7 +17,6 @@ header h1{
     margin-top:0px;
     margin-bottom: 0px;
     font-size: 2.3em;
-    
 }
 </style>
 {% endblock %}
@@ -35,7 +34,12 @@ header h1{
 
     {% if not items %}
 
-    {%trans%}Sorry, no items added since now{%endtrans%}
+    <div class="list-warning">
+        <div class="alert alert-warning" role="alert">
+            <span class="sr-only">Error:</span>
+            {%trans%}No items added since now{%endtrans%}
+        </div>
+    <div>
 
     {% else %}
 
@@ -61,7 +65,8 @@ header h1{
                     <li><span class="glyphicon glyphicon-time"></span>
                         <date data-timestamp="{{ b['fields']['_timestamp'] }}">
                             {{ b['fields']['_timestamp'] | timepassedformat }}
-                        </date></li>
+                        </date>
+                    </li>
                     <li><span class="glyphicon glyphicon-flag"></span> {{ b['_source']['_language'] }}</li>
                     {% if 'actors' in b['_source'] %}
                     <li><span class="glyphicon glyphicon-user"></span> {{ b['_source']['actors'] | join(',')}}</li>
@@ -87,5 +92,5 @@ header h1{
         $(this).text(date.toLocaleString());
     });
     </script>
-    <script src="{{ url_for('static', filename='js/ui-main.js') }}"></script>    
+    <script src="{{ url_for('static', filename='js/ui-main.js') }}"></script>
 {% endblock scripts %}

--- a/webant/templates/search.html
+++ b/webant/templates/search.html
@@ -13,68 +13,78 @@ Libreant | {%trans%}Search{%endtrans%}: {{ query }}
 
 {% block styles %}
 {{ super() }}
-<link href="{{ url_for('static', filename='search.css') }}" rel="stylesheet">
+<link href="{{ url_for('static', filename='item_list.css') }}" rel="stylesheet">
+<style>
+.search-info{
+    margin-top: 10px;
+    margin-bottom: 10px;
+    font-size: 0.8em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+</style>
 {% endblock styles %}
 
 {% block content %}
 <div class="container">
     
-    {{ searchbar.searchbar(search_query=query) }}
-
-    <hr />
+    <div class="search-bar">
+        {{ searchbar.searchbar(search_query=query) }}
+    </div>
     
-    <hgroup class="mb20">
-        <h1>{%trans%}Search results{%endtrans%}</h1>
-        <h2 class="lead">{% trans num = books|length%}{{num}} result was found for{%pluralize%}{{num}} results were found for{% endtrans %} <strong>{{ query }}</strong></h2>
-    </hgroup>
+    <div class='search-info'>
+        {% trans num = books|length%}{{num}} result was found for{%pluralize%}{{num}} results were found for{% endtrans %} <strong>{{ query }}</strong>
+    </div>
 
     {% if not books %}
 
-    {%trans%}Sorry, no books matching your query{%endtrans%}
+    <div class="list-warning">
+        <div class="alert alert-warning" role="alert">
+            <span class="sr-only">Error:</span>
+            {%trans%}Sorry, no books matching your query{%endtrans%}
+        </div>
+    <div>
 
     {% else %}
 
-    <section class="search-results col-xs-12 col-sm-12 col-md-12 col-lg-12">
-    {% for b in books %}
-    <article class="search-result row">
-        <div class="hidden-xs col-sm-2 col-md-2 col-lg-2">
-		{# TODO: cover image #}
-		<a href="{{url_for('view_book', bookid=b['_id'])}}"
-			title="{{ b['_id'] }}">
-			<i class="glyphicon glyphicon-book"
-				style="font-size: 400%"></i>
-		</a>
+    <div id="item-list">
+        {% for b in books %}
+        <div class="item-div row dyn-href" href="{{url_for('view_book', bookid=b['_id'])}}">
+            <div class="item-thumbnail hidden-xs col-sm-1 vcenter">
+                <a href="{{url_for('view_book', bookid=b['_id'])}}">
+			        <span class="glyphicon glyphicon-book"></span>
+		        </a>
+            </div>
+            <div class="item-main col-xs-12 col-sm-7 vcenter">
+                <a class="item-title" href="{{url_for('view_book', bookid=b['_id'])}}"
+                    {% if 'title' in b %}
+                        title="{{ b['title'] }}"> {{ b['title'] }}
+                    {% else %}
+                        title="{{ b['_id'] }}"> {{ b['_id'] }}
+                    {% endif %}
+                </a>
+            </div>
+            <div class="item-sub col-xs-12 col-sm-3 vcenter">
+                <ul class="meta-list list-unstyled">
+                    <li><span class="glyphicon glyphicon-flag"></span> {{ b['_language'] }}</li>
+                    {% if 'actors' in b %}
+                    <li><span class="glyphicon glyphicon-user"></span> {{ b['actors'] | join(',')}}</li>
+                    {% endif %}
+                    {% if '_files' in b %}
+                    <li><span class="glyphicon glyphicon-file"></span> {{ b['_files'] | length }}</li>
+                    {% endif %}
+                </ul>
+            </div>
         </div>
-        <div class="col-xs-12 col-sm-5 col-md-6 col-lg-6 excerpet">
-            <h3><a href="{{url_for('view_book', bookid=b['_id'])}}" title="{{ b['_id'] }}">
-                    {{ b['title'] }}
-            </a></h3>
-        </div>
-        <div class="col-xs-12 col-sm-5 col-md-4 col-lg-4">
-            <ul class="meta-search">
-                {# TODO: default_locale.languages[b['_language']] #}
-                <li><i class="glyphicon glyphicon-flag"></i> <span>{{ b['_language'] }}</span></li>
-                {% if 'actors' in b %}
-                <li><i class="glyphicon glyphicon-user"></i> <span>{{ b['actors'] | join(',')}}</span></li>
-                {% endif %}
-                {% if 'tags' in b %}
-                <li><i class="glyphicon glyphicon-tags"></i> <span>{{ b['tags'] | join(',') }}</span></li>
-                {% endif %}
-                {% if 'location' in b %}
-		<li><i class="glyphicon glyphicon-globe"></i>
-			<span title="{{ b['location'] }}">
-				{{ b['location'] | truncate(length=40) }}
-			</span></li>
-                {% endif %}
-            </ul>
-        </div>
-        <span class="clearfix border"></span>
-    </article>
-    {% endfor %}
-    </section>
+        {% endfor %}
+    </div>
 
     {% endif %}
-
 </div>
 {% endblock content %}
 
+{% block scripts %}
+    {{super()}}
+    <script src="{{ url_for('static', filename='js/ui-main.js') }}"></script>
+{% endblock scripts %}

--- a/webant/templates/searchbar.html
+++ b/webant/templates/searchbar.html
@@ -5,7 +5,9 @@
         <input name="q" class="form-control" type="text" value="{{ search_query }}"/>
         <span class="input-group-btn">
             <button type="submit" class="btn btn-primary">
-            <span class="glyphicon glyphicon-search" aria-hidden="true"></span> {%trans%}Search{%endtrans%}</button>
+                <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+                <span class="hidden-xs">{%trans%}Search{%endtrans%}</span>
+            </button>
         </span>
     </div>
 </form>


### PR DESCRIPTION
##### searchbar::
on extra-small screen search button label will be hidden in order to give more space to the textbox.

##### warnings:
item-list warnings are now prettier and centered

Old:
![warning_old](https://cloud.githubusercontent.com/assets/4229536/6495989/03953e10-c2cf-11e4-8c1e-ceb652cf3070.png)
New:
![warning_new](https://cloud.githubusercontent.com/assets/4229536/6495992/08aa07c8-c2cf-11e4-862b-96b7d2c24394.png)

##### search result list:
style is cohesive with recently_added page.
we handle properly long title and search query string ( fixes #48 )

Old:
![screenshot from 2015-03-05 00 26 37](https://cloud.githubusercontent.com/assets/4229536/6496038/6b8d2eba-c2cf-11e4-861d-79e178f06aa7.png)

New:
![screenshot from 2015-03-05 00 13 32](https://cloud.githubusercontent.com/assets/4229536/6496047/8070122a-c2cf-11e4-807a-5dfcbfc6bb96.png)