### PR TITLE
stop using script to increment download count

### DIFF
--- a/libreantdb/api.py
+++ b/libreantdb/api.py
@@ -209,9 +209,12 @@ class DB(object):
         '''
         Increment the download counter of a specific file
         '''
-        body = { 'script' : 'ctx._source._files[%i].download_count += 1' % fileIndex }
-        return self.es.update(index=self.index_name, id=id,
-                             doc_type=doc_type, body=body)
+        body = self.es.get(index=self.index_name, id=id, doc_type='book', _source_include='_files')['_source']
+
+        body['_files'][fileIndex]['download_count'] += 1
+
+        self.es.update(index=self.index_name, id=id,
+                             doc_type=doc_type, body={"doc":body})
     # End operations }}}
 
 # vim: set fdm=marker fdl=1:

--- a/libreantdb/test/test_update.py
+++ b/libreantdb/test/test_update.py
@@ -94,3 +94,19 @@ def test_update_download_count():
         db.increment_download_count(id_, 0)
         book = db.get_book_by_id(id_)
         eq_(book['_source']['_files'][0]['download_count'], i)
+
+
+@with_setup(cleanall, cleanall)
+def test_update_download_count():
+    ''' download count shouldn't modify other fields '''
+    id_ = db.add_book(doc_type='book',
+                      body=dict(title='La fine', _language='it',
+                                _files=[dict(
+                                    download_count=4,
+                                    name='foo'
+                                )]))['_id']
+    prev = db.get_book_by_id(id_)
+    db.increment_download_count(id_, 0)
+    after = db.get_book_by_id(id_)
+    prev['_source']['_files'][0]['download_count'] += 1
+    eq_(prev['_source'], after['_source'])


### PR DESCRIPTION
dynamic scripting was disable by default since version 1.4.3 and has a security bug in previous versions.

If you want to read more:
https://www.elastic.co/blog/scripting-security
http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html
http://bouk.co/blog/elasticsearch-rce/

At the moment we rely on scripting only for download count increment, in this commit I dropped the scripting way in favor of the classic fetch and update one.