### PR TITLE
{libreantdb} setup_db() now wait for index to be ready

### DIFF
--- a/webant/webant.py
+++ b/webant/webant.py
@@ -78,7 +78,7 @@ def initLoggers(logLevel=logging.WARNING):
         '%(asctime)s [%(name)s] [%(levelname)s] %(message)s')
     streamHandler.setFormatter(formatter)
     loggers = map(logging.getLogger,
-                  ('webant', 'fsdb', 'presets', 'agherant', 'config_utils'))
+                  ('webant', 'fsdb', 'presets', 'agherant', 'config_utils', 'libreantdb'))
     for logger in loggers:
         logger.setLevel(logLevel)
         if not logger.handlers:


### PR DESCRIPTION
In previous code version, we initialize index but we did not wait for ready status, so we used to encounter TransportError.
Now the default fashion is to wait ready status for the index.
I also added logging capabilities to this module in order to notify the blocking call.
