### PR TITLE
tests cleanup

### DIFF
--- a/libreantdb/test/__init__.py
+++ b/libreantdb/test/__init__.py
@@ -1,9 +1,6 @@
-import sys
-sys.path.append('..')
-sys.path.append('../..')
+from libreantdb import DB
 from elasticsearch import Elasticsearch
 
-from libreantdb import api, DB
 
 es = Elasticsearch()
 db = DB(es, index_name='test-book')

--- a/libreantdb/test/test_fts.py
+++ b/libreantdb/test/test_fts.py
@@ -3,7 +3,6 @@ This module will connect to your elasticsearch instance.
 An index will be reserved to the tests.
 '''
 from __future__ import print_function
-from pprint import pprint
 
 from nose.tools import eq_, with_setup
 
@@ -33,9 +32,9 @@ def test_fts_it_plural_manual():
     query = 'donne'
     db.add_book(doc_type='book', body=dict(title=title, _language='it'))
     for phrase in title, query:
-        pprint(db.es.indices.analyze(index=db.index_name,
-                                     body=phrase,
-                                     analyzer='it_analyzer')['tokens'])
+        db.es.indices.analyze(index=db.index_name,
+                              body=phrase,
+                              analyzer='it_analyzer')['tokens']
     db.es.indices.refresh(index=db.index_name)
 
     res = db._search(db._get_search_field('_text_it', query))
@@ -50,9 +49,9 @@ def test_fts_it_plural():
     wrong_query = 'donato'
     db.add_book(doc_type='book', body=dict(title=title, _language='it'))
     for phrase in title, query:
-        pprint(db.es.indices.analyze(index=db.index_name,
-                                     body=phrase,
-                                     analyzer='it_analyzer')['tokens'])
+        db.es.indices.analyze(index=db.index_name,
+                              body=phrase,
+                              analyzer='it_analyzer')['tokens']
     db.es.indices.refresh(index=db.index_name)
 
     res = db.get_books_multilanguage(query)
@@ -69,9 +68,9 @@ def test_fts_en_manual():
     wrong_query = 'love'
     db.add_book(doc_type='book', body=dict(title=title, _language='en'))
     for phrase in title, query, wrong_query:
-        pprint(db.es.indices.analyze(index=db.index_name,
-                                     body=phrase,
-                                     analyzer='english')['tokens'])
+        db.es.indices.analyze(index=db.index_name,
+                              body=phrase,
+                              analyzer='english')['tokens']
     db.es.indices.refresh(index=db.index_name)
     res = db._search(db._get_search_field('_text_en', 'living'))
     eq_(res['hits']['total'], 1)
@@ -89,9 +88,9 @@ def test_fts_en_verbs():
     wrong_query = 'love'
     db.add_book(doc_type='book', body=dict(title=title, _language='en'))
     for phrase in title, query, wrong_query:
-        pprint(db.es.indices.analyze(index=db.index_name,
-                                     body=phrase,
-                                     analyzer='english')['tokens'])
+        db.es.indices.analyze(index=db.index_name,
+                              body=phrase,
+                              analyzer='english')['tokens']
     db.es.indices.refresh(index=db.index_name)
     res = db.get_books_multilanguage('living')
     eq_(res['hits']['total'], 1)
@@ -109,9 +108,9 @@ def test_fts_en_plural():
     wrong_query = 'buggy'
     db.add_book(doc_type='book', body=dict(title=title, _language='en'))
     for phrase in title, query, wrong_query:
-        pprint(db.es.indices.analyze(index=db.index_name,
-                                     body=phrase,
-                                     analyzer='english')['tokens'])
+        db.es.indices.analyze(index=db.index_name,
+                              body=phrase,
+                              analyzer='english')['tokens']
     db.es.indices.refresh(index=db.index_name)
     res = db.get_books_multilanguage('bugs')
     eq_(res['hits']['total'], 1)

--- a/libreantdb/test/test_last_inserted.py
+++ b/libreantdb/test/test_last_inserted.py
@@ -1,5 +1,6 @@
-from nose.tools import eq_, with_setup, ok_
+from nose.tools import eq_, with_setup
 from . import db, cleanall
+
 
 @with_setup(cleanall, cleanall)
 def test_last():
@@ -8,7 +9,7 @@ def test_last():
     '''
     num = 4
     ids = []
-    for i in range(0,num):
+    for i in range(0, num):
         ids.append(db.add_book(doc_type='book',
                    body=dict(title='ma che ne so {}'.format(i), _language='it'))['_id'])
     db.es.indices.refresh(index=db.index_name)
@@ -16,6 +17,7 @@ def test_last():
     eq_(len(hits), num)
     for hit, id in zip(hits, reversed(ids)):
         eq_(hit['_id'], id)
+
 
 @with_setup(cleanall, cleanall)
 def test_has_timestamp():

--- a/libreantdb/test/test_length.py
+++ b/libreantdb/test/test_length.py
@@ -2,7 +2,6 @@
 This module will connect to your elasticsearch instance.
 An index will be reserved to the tests.
 '''
-from __future__ import print_function
 
 from nose.tools import eq_, with_setup
 

--- a/libreantdb/test/test_mlt.py
+++ b/libreantdb/test/test_mlt.py
@@ -2,10 +2,7 @@
 More like this
 '''
 
-from __future__ import print_function
-
 from nose.tools import eq_, with_setup
-
 from . import db, cleanall
 
 
@@ -75,7 +72,7 @@ def test_mlt_en_topic():
 
 
 @with_setup(cleanall, cleanall)
-def test_mlt_en_topic():
+def test_mlt_en_topic_2():
     '''MLT: There are two books; one about same topic, one totally different'''
     b = dict(title='On the origins of Africa',
              actors=['marco', 'giulio'],

--- a/libreantdb/test/test_query.py
+++ b/libreantdb/test/test_query.py
@@ -2,11 +2,11 @@
 This module will connect to your elasticsearch instance.
 An index will be reserved to the tests.
 '''
-from __future__ import print_function
 
 from nose.tools import eq_, with_setup, raises
 
-from . import db, api, cleanall
+from libreantdb import api
+from . import db, cleanall
 
 
 @with_setup(cleanall)

--- a/libreantdb/test/test_sorted_search.py
+++ b/libreantdb/test/test_sorted_search.py
@@ -3,8 +3,6 @@ This module will connect to your elasticsearch instance.
 An index will be reserved to the tests.
 '''
 
-from pprint import pprint
-
 from nose.tools import eq_, with_setup
 
 from . import db, cleanall
@@ -13,9 +11,8 @@ from . import db, cleanall
 @with_setup(cleanall, cleanall)
 def test_last_inserted():
     '''Simple fts, without stemming or anything fancy'''
-    first = db.add_book( body={ 'order': 'first', '_language':'it'} )
-    second = db.add_book( body={ 'order': 'second', '_language':'it'} )
+    first = db.add_book(body={'order': 'first', '_language': 'it'})
+    second = db.add_book(body={'order': 'second', '_language': 'it'})
     db.es.indices.refresh(index=db.index_name)
     res = db.get_last_inserted(1)
-    pprint(res)
-    eq_(res['hits']['hits'][0]['_id'],  second['_id'])
+    eq_(res['hits']['hits'][0]['_id'], second['_id'])

--- a/libreantdb/test/test_update.py
+++ b/libreantdb/test/test_update.py
@@ -2,7 +2,6 @@
 This module will connect to your elasticsearch instance.
 An index will be reserved to the tests.
 '''
-from __future__ import print_function
 
 from nose.tools import eq_, with_setup, ok_, raises
 
@@ -97,7 +96,7 @@ def test_update_download_count():
 
 
 @with_setup(cleanall, cleanall)
-def test_update_download_count():
+def test_update_download_count_no_other_mod():
     ''' download count shouldn't modify other fields '''
     id_ = db.add_book(doc_type='book',
                       body=dict(title='La fine', _language='it',

--- a/libreantdb/test/test_validate.py
+++ b/libreantdb/test/test_validate.py
@@ -1,8 +1,6 @@
-from __future__ import print_function
-
 from nose.tools import eq_, raises, assert_raises
 
-from .import api
+from libreantdb import api
 
 validate_book = api.validate_book
 collectStrings = api.collectStrings

--- a/presets/test/test_preset_paths.py
+++ b/presets/test/test_preset_paths.py
@@ -12,11 +12,19 @@ from presets.presetManager import PresetManager
 
 
 minimalBody = { "id": "id_test",
-                    "properties": []
-                  }
+                "properties": [] }
 
-def json_tmp_file(**kwargs):
-    return NamedTemporaryFile(delete=False, suffix=".json", **kwargs)
+tmpDir = None
+
+def setUpModule():
+    global tmpDir
+    tmpDir = mkdtemp(prefix='libreant_presets_tests')
+
+def tearDownModule():
+    rmtree(tmpDir)
+
+def json_tmp_file():
+    return NamedTemporaryFile(delete=False, dir=tmpDir, suffix=".json")
 
 def test_sigle_file():
     ''' test single file loding'''
@@ -24,7 +32,6 @@ def test_sigle_file():
     file.write(json.dumps(minimalBody))
     file.close()
     p = PresetManager(file.name, strict=True)
-    os.unlink(file.name)
     assert minimalBody['id'] in p.presets
 
 
@@ -73,10 +80,10 @@ def test_folders():
     presetBodies = list()
     num = 5
     for i in range(num):
-        folders.append(mkdtemp())
+        folders.append(mkdtemp(dir=tmpDir))
         presetBodies.append(minimalBody.copy())
         presetBodies[i]['id'] = "id_" + str(i)
-        file = json_tmp_file(dir=folders[i])
+        file = NamedTemporaryFile(delete=False, dir=folders[i], suffix=".json")
         file.write(json.dumps(presetBodies[i]))
         file.close()
 


### PR DESCRIPTION
**presets**
Tests inside ```presets/test/test_preset_paths.py``` were leaving tmp files around.
Now we create a tmp folder during module set-up, during test we only touch files inside this folder and finally we delete this folder on module tear-down function. 

**libreantdb**
 - some tests had same name.
 - some import were unuseful.
 - some test were printing on stdout.
 - some anti-pep8 formatting.
