### PR TITLE
Archivant insertion

### DIFF
--- a/archivant/__init__.py
+++ b/archivant/__init__.py
@@ -1,0 +1,1 @@
+from archivant import Archivant

--- a/archivant/archivant.py
+++ b/archivant/archivant.py
@@ -1,11 +1,13 @@
 import os
 from elasticsearch import Elasticsearch
+from elasticsearch import NotFoundError
 from uuid import uuid4
 from fsdb import Fsdb
 from fsdb.hashtools import calc_file_digest, calc_digest
 from copy import deepcopy
 
 from libreantdb import DB
+from exceptions import NotFoundException
 
 from logging import getLogger
 log = getLogger('archivant')
@@ -44,6 +46,71 @@ class Archivant():
                 index_name=self._config['ES_INDEXNAME'])
         db.setup_db()
         self._db = db
+
+    @staticmethod
+    def normalize_volume(volume):
+        '''convert volume metadata from es to archivant format
+
+           output example:
+           {
+            'id': 'AU0paPZOMZchuDv1iDv8',
+            'type': 'volume',
+            'metadata': {'_language': 'en',
+                         'key1': 'value1',
+                         'key2': 'value2',
+                         'key3': 'value3'},
+            'attachments': [{'id': 'a910e1kjdo2d192d1dko1p2kd1209d',
+                             'type' : 'attachment',
+                             'url': 'fsdb:///624bffa8a6f90813b7982d0e5b4c1475ebec40e3',
+                             'metadata': {'download_count': 0,
+                                          'mime': 'application/json',
+                                          'name': 'tmp9fyat_',
+                                          'notes': 'this file is awsome',
+                                          'sha1': '624bffa8a6f90813b7982d0e5b4c1475ebec40e3',
+                                          'size': 10}
+                           }]
+           }
+        '''
+        res = dict()
+        res['type'] = 'volume'
+        res['id'] = volume['_id']
+        if '_score' in volume:
+            res['score'] = volume['score']
+
+        source = volume['_source']
+        attachments = source['_attachments']
+        del(source['_attachments'])
+        del(source['_text_' + source['_language']])
+        res['metadata'] = source
+
+        atts = list()
+        for attachment in attachments:
+            atts.append(Archivant.normalize_attachment(attachment))
+        res['attachments'] = atts
+
+        return res
+
+    @staticmethod
+    def normalize_attachment(attachment):
+        ''' Convert attachment metadata from es to archivant format '''
+        res = dict()
+        res['type'] = 'attachment'
+        res['id'] = attachment['id']
+        del(attachment['id'])
+        res['url'] = attachment['url']
+        del(attachment['url'])
+        res['metadata'] = attachment
+        return res
+
+    def _req_raw_volume(self, volumeID):
+        try:
+            return self._db.get_book_by_id(volumeID)
+        except NotFoundError:
+            raise NotFoundException("could not found volume with id: '{}'".format(volumeID))
+
+    def get_volume(self, volumeID):
+        log.debug("Requested volume with id:'{}'".format(volumeID))
+        return Archivant.normalize_volume(self._req_raw_volume(volumeID))
 
     def insert_volume(self, metadata, attachments=[]):
         '''Insert a new volume

--- a/archivant/archivant.py
+++ b/archivant/archivant.py
@@ -1,0 +1,41 @@
+from fsdb import Fsdb
+from libreantdb import DB
+from elasticsearch import Elasticsearch
+
+from logging import getLogger
+log = getLogger('archivant')
+
+
+class Archivant():
+    ''' Implementation of a Data Access Layer
+
+        Archivant handling both an fsdb instance and
+        a libreantdb one exposes an API to operate on 'volumes'.
+
+        A 'volume' represents a physical/digital object stored within archivant.
+        Volumes are structured as described in `Archivant.normalize_volume`,
+        these have metadata and a list of attachments.
+    '''
+
+    def __init__(self, conf={}):
+        defaults = {
+            'FSDB_PATH': "",
+            'ES_HOSTS': None,
+            'ES_INDEXNAME': ''
+        }
+        defaults.update(conf)
+        self._config = defaults
+        log.debug('initializing with this config: ' + str(self._config))
+
+        # initialize fsdb
+        if not self._config['FSDB_PATH']:
+            raise ValueError('FSDB_PATH cannot be empty')
+        self._fsdb = Fsdb(self._config['FSDB_PATH'])
+
+        # initialize elasticsearch
+        if not self._config['ES_INDEXNAME']:
+            raise ValueError('ES_INDEXNAME cannot be empty')
+        db = DB(Elasticsearch(hosts=self._config['ES_HOSTS']),
+                index_name=self._config['ES_INDEXNAME'])
+        db.setup_db()
+        self._db = db

--- a/archivant/archivant.py
+++ b/archivant/archivant.py
@@ -1,6 +1,11 @@
-from fsdb import Fsdb
-from libreantdb import DB
+import os
 from elasticsearch import Elasticsearch
+from uuid import uuid4
+from fsdb import Fsdb
+from fsdb.hashtools import calc_file_digest, calc_digest
+from copy import deepcopy
+
+from libreantdb import DB
 
 from logging import getLogger
 log = getLogger('archivant')
@@ -39,3 +44,86 @@ class Archivant():
                 index_name=self._config['ES_INDEXNAME'])
         db.setup_db()
         self._db = db
+
+    def insert_volume(self, metadata, attachments=[]):
+        '''Insert a new volume
+
+           Returns the ID of the added volume
+
+           `metadata` must be a dict containg metadata of the volume.
+           The only required key is `_language`
+           {
+             "_language" : "it",  # language of the metadata
+             "key1" : "value1",   # attribute
+             "key2" : "value2",
+              ...
+             "keyN" : "valueN"
+           }
+
+           `attachments` must be an array of dict
+           {
+               "file"  : "/prova/una/path/a/caso" # path or fp
+               "name"  : "nome_buffo.ext"         # name of the file (extension included) [optional if a path was given]
+               "mime"  : "application/json"       # mime type of the file [optional]
+               "notes" : "this file is awesome"   # notes that will be attached to this file [optional]
+           }
+        '''
+
+        log.debug("adding new volume:\n\tdata: {}\n\tfiles: {}".format(metadata, attachments))
+
+        requiredFields = ['_language']
+        for requiredField in requiredFields:
+            if requiredField not in metadata:
+                raise KeyError("Required field '{}' is missing".format(requiredField))
+
+        volume = deepcopy(metadata)
+
+        attsData = []
+        for index, a in enumerate(attachments):
+            attData = {}
+            # file is not optional
+            if 'file' not in a:
+                raise KeyError("`file` key not found in attachments array at index {}".format(index))
+
+            locator = a['file']
+            if isinstance(locator, basestring):
+                if not os.path.isfile(locator):
+                    raise ValueError("'{}' is not a regular file. attachments array at index {}".format(locator, index))
+                attData['name'] = a['name'] if 'name' in a else os.path.basename(locator)
+                attData['size'] = os.path.getsize(locator)
+                attData['sha1'] = calc_file_digest(locator, algorithm="sha1")
+
+            elif hasattr(locator, 'read') and hasattr(locator, 'seek'):
+                if 'name' in a and a['name']:
+                    attData['name'] = a['name']
+                elif hasattr(locator, 'name'):
+                    attData['name'] = locator.name
+                else:
+                    raise ValueError("Could not assign a name to the file. attachments array at index {}".format(index))
+
+                old_position = locator.tell()
+
+                locator.seek(0, os.SEEK_END)
+                attData['size'] = locator.tell() - old_position
+                locator.seek(old_position, os.SEEK_SET)
+
+                attData['sha1'] = calc_digest(locator, algorithm="sha1")
+                locator.seek(old_position, os.SEEK_SET)
+
+            else:
+                raise ValueError("unsupported file value type {} in attachments array at index {}".format(type(locator), index))
+
+            attData['id'] = uuid4().hex
+            attData['mime'] = a['mime'] if 'mime' in a else None
+            attData['notes'] = a['notes'] if 'notes' in a else ""
+            attData['download_count'] = 0
+            fsdb_id = self._fsdb.add(locator)
+            attData['url'] = "fsdb:///" + fsdb_id
+            attsData.append(attData)
+
+        volume['_attachments'] = attsData
+
+        log.debug('constructed volume for insertion: {}'.format(volume))
+        addedVolume = self._db.add_book(body=volume)
+        log.debug("added new volume: '{}'".format(addedVolume['_id']))
+        return addedVolume['_id']

--- a/archivant/exceptions.py
+++ b/archivant/exceptions.py
@@ -1,0 +1,2 @@
+class NotFoundException(Exception):
+    pass

--- a/archivant/test/__init__.py
+++ b/archivant/test/__init__.py
@@ -1,0 +1,1 @@
+from class_template import TestArchivant

--- a/archivant/test/class_template.py
+++ b/archivant/test/class_template.py
@@ -1,0 +1,57 @@
+from archivant import Archivant
+from elasticsearch import Elasticsearch
+from tempfile import mkdtemp, mkstemp
+from shutil import rmtree
+import random
+import os
+import string
+
+
+class TestArchivant():
+
+    TEST_ES_INDEX = 'test-archivant'
+    FSDB_PATH_PREFIX = "archivant_test_"
+
+    @classmethod
+    def setUpClass(self):
+        self.es = Elasticsearch()
+
+    @classmethod
+    def tearDownClass(self):
+        self.es.indices.delete(self.TEST_ES_INDEX)
+
+    def setUp(self):
+        self.tmpDir = mkdtemp(prefix=self.FSDB_PATH_PREFIX)
+        conf = {'ES_INDEXNAME': self.TEST_ES_INDEX,
+                'FSDB_PATH': self.tmpDir}
+        self.arc = Archivant(conf)
+
+    def tearDown(self):
+        self.es.delete_by_query(index=self.TEST_ES_INDEX,
+                                body={'query': {'match_all': {}}})
+        rmtree(self.tmpDir)
+        self.tmpDir = None
+        self.arc = None
+
+    @staticmethod
+    def generate_volume_metadata():
+        return {'_language': 'en',
+                'key1': 'value1',
+                'key2': 'value2',
+                'key3': 'value3'}
+
+    @staticmethod
+    def random_string(length):
+        return ''.join(random.choice(string.hexdigits) for _ in range(length))
+
+    def generate_file(self):
+        fd, path = mkstemp(dir=self.tmpDir)
+        with os.fdopen(fd, 'wb') as f:
+            f.write(self.random_string(10))
+        return path
+
+    def generate_attachments(self, n):
+        files = []
+        for i in range(0, n):
+            files.append({'file': self.generate_file()})
+        return files

--- a/archivant/test/test_get_attachment.py
+++ b/archivant/test/test_get_attachment.py
@@ -1,0 +1,28 @@
+from archivant.test import TestArchivant
+from fsdb.hashtools import calc_file_digest
+from StringIO import StringIO
+
+from nose.tools import raises, ok_, eq_
+import os
+
+
+class TestArchivantGetAttachment(TestArchivant):
+
+    def test_get_attachment(self):
+        volume_metadata = self.generate_volume_metadata()
+        attachments = self.generate_attachments(1)
+        id = self.arc.insert_volume(volume_metadata, attachments=attachments)
+        added_volume = self.arc.get_volume(id)
+        print added_volume['attachments'][0]['id']
+        self.arc.get_attachment(id, added_volume['attachments'][0]['id'])
+
+    def test_get_file(self):
+        content = "unascrittaperprovare"
+        volume_metadata = self.generate_volume_metadata()
+        s = StringIO(content)
+        volume_metadata = self.generate_volume_metadata()
+        attachments = [{'file': s, 'name': 'I_love.json'}]
+        volumeID = self.arc.insert_volume(volume_metadata, attachments=attachments)
+        added_volume = self.arc.get_volume(volumeID)
+        file = self.arc.get_file(volumeID, added_volume['attachments'][0]['id'])
+        eq_(file.read(), content)

--- a/archivant/test/test_get_volume.py
+++ b/archivant/test/test_get_volume.py
@@ -1,0 +1,16 @@
+from archivant.test import TestArchivant
+from archivant.exceptions import NotFoundException
+from nose.tools import raises, ok_, eq_
+import os
+
+
+class TestArchivantGetVolume(TestArchivant):
+
+    @raises(NotFoundException)
+    def test_get_volume_notexistent(self):
+        self.arc.get_volume("unidchenonesiste")
+        
+    def test_get_volume(self):
+        volume_metadata = self.generate_volume_metadata()
+        id = self.arc.insert_volume(volume_metadata)
+        self.arc.get_volume(id)

--- a/archivant/test/test_insert_volume.py
+++ b/archivant/test/test_insert_volume.py
@@ -1,0 +1,131 @@
+from archivant.test import TestArchivant
+from fsdb.hashtools import calc_file_digest, calc_digest
+
+from nose.tools import raises, ok_, eq_
+import os
+from StringIO import StringIO
+
+
+class TestArchivantInsert(TestArchivant):
+
+    def test_insert_volume(self):
+        volume_metadata = self.generate_volume_metadata()
+        id = self.arc.insert_volume(volume_metadata)
+
+    @raises(KeyError)
+    def test_insert_volume_without_language(self):
+        id = self.arc.insert_volume({'key0': 'value0'})
+
+    def test_insert_volume_check_metadata(self):
+        volume_metadata = self.generate_volume_metadata()
+        id = self.arc.insert_volume(volume_metadata)
+        added_volume = self.arc.get_volume(id)
+        ok_('id' in added_volume)
+        eq_(added_volume['type'], 'volume')
+        eq_(len(volume_metadata), len(added_volume['metadata']))
+        for k, v in volume_metadata.items():
+            eq_(added_volume['metadata'][k], v)
+
+    def test_insert_volume_no_files(self):
+        volume_metadata = self.generate_volume_metadata()
+        id = self.arc.insert_volume(volume_metadata)
+        added_volume = self.arc.get_volume(id)
+        eq_(len(added_volume['attachments']), 0)
+
+    def test_insert_volume_one_file(self):
+        volume_metadata = self.generate_volume_metadata()
+        attachments = self.generate_attachments(1)
+        id = self.arc.insert_volume(volume_metadata, attachments=attachments)
+        added_attachments = (self.arc.get_volume(id))['attachments']
+        eq_(len(added_attachments), 1)
+        ok_('id' in added_attachments[0])
+        eq_(added_attachments[0]['type'], 'attachment')
+
+    def test_insert_volume_one_file_default_metadata(self):
+        volume_metadata = self.generate_volume_metadata()
+        attachments = self.generate_attachments(1)
+        id = self.arc.insert_volume(volume_metadata, attachments=attachments)
+        att_metadata = (self.arc.get_volume(id))['attachments'][0]['metadata']
+        eq_(att_metadata['mime'], None)
+        eq_(att_metadata['notes'], "")
+
+    def test_insert_volume_one_file_dinamic_metadata(self):
+        volume_metadata = self.generate_volume_metadata()
+        attachments = self.generate_attachments(1)
+        id = self.arc.insert_volume(volume_metadata, attachments=attachments)
+        att_metadata = (self.arc.get_volume(id))['attachments'][0]['metadata']
+        eq_(att_metadata['download_count'], 0)
+        eq_(att_metadata['name'], os.path.basename(attachments[0]['file']))
+        eq_(att_metadata['size'], os.path.getsize(attachments[0]['file']))
+        eq_(att_metadata['sha1'], calc_file_digest(attachments[0]['file'],
+                                                   algorithm='sha1'))
+
+    def test_insert_volume_one_file_mime(self):
+        volume_metadata = self.generate_volume_metadata()
+        attachments = self.generate_attachments(1)
+        attachments[0]['mime'] = 'application/json'
+        id = self.arc.insert_volume(volume_metadata, attachments=attachments)
+        att_metadata = (self.arc.get_volume(id))['attachments'][0]['metadata']
+        eq_(att_metadata['mime'], attachments[0]['mime'])
+
+    def test_insert_volume_one_file_notes(self):
+        volume_metadata = self.generate_volume_metadata()
+        attachments = self.generate_attachments(1)
+        attachments[0]['notes'] = 'this file is awsome'
+        id = self.arc.insert_volume(volume_metadata, attachments=attachments)
+        att_metadata = (self.arc.get_volume(id))['attachments'][0]['metadata']
+        eq_(att_metadata['notes'], attachments[0]['notes'])
+
+    def test_insert_volume_one_file_name(self):
+        volume_metadata = self.generate_volume_metadata()
+        attachments = self.generate_attachments(1)
+        attachments[0]['name'] = 'I_love.json'
+        id = self.arc.insert_volume(volume_metadata, attachments=attachments)
+        att_metadata = (self.arc.get_volume(id))['attachments'][0]['metadata']
+        eq_(att_metadata['name'], attachments[0]['name'])
+
+    def test_insert_volume_with_three_file(self, num=3):
+        volume_metadata = self.generate_volume_metadata()
+        attachments = self.generate_attachments(num)
+        id = self.arc.insert_volume(volume_metadata, attachments=attachments)
+        added_attachments = (self.arc.get_volume(id))['attachments']
+        eq_(len(added_attachments), num)
+
+    @raises(ValueError)
+    def test_insert_volume_with_readable_no_name(self):
+        s = StringIO('unascrittaperprovare')
+        volume_metadata = self.generate_volume_metadata()
+        attachments = [{'file': s}]
+        id = self.arc.insert_volume(volume_metadata, attachments=attachments)
+
+    def test_insert_volume_with_readable(self):
+        s = StringIO('unascrittaperprovare')
+        volume_metadata = self.generate_volume_metadata()
+        attachments = [{'file': s, 'name': 'I_love.json'}]
+        id = self.arc.insert_volume(volume_metadata, attachments=attachments)
+        added_attachments = (self.arc.get_volume(id))['attachments']
+        eq_(len(added_attachments), 1)
+        ok_('id' in added_attachments[0])
+        eq_(added_attachments[0]['type'], 'attachment')
+
+    def test_insert_volume_with_readable_default_metadata(self):
+        volume_metadata = self.generate_volume_metadata()
+        s = StringIO('unascrittaperprovare')
+        volume_metadata = self.generate_volume_metadata()
+        attachments = [{'file': s, 'name': 'I_love.json'}]
+        id = self.arc.insert_volume(volume_metadata, attachments=attachments)
+        att_metadata = (self.arc.get_volume(id))['attachments'][0]['metadata']
+        eq_(att_metadata['mime'], None)
+        eq_(att_metadata['notes'], "")
+
+    def test_insert_volume_with_readable_dinamic_metadata(self):
+        s = StringIO('unascrittaperprovare')
+        volume_metadata = self.generate_volume_metadata()
+        attachments = [{'file': s, 'name': 'I_love.json'}]
+        id = self.arc.insert_volume(volume_metadata, attachments=attachments)
+        att_metadata = (self.arc.get_volume(id))['attachments'][0]['metadata']
+        eq_(att_metadata['download_count'], 0)
+        eq_(att_metadata['name'], 'I_love.json')
+        eq_(att_metadata['size'], s.len)
+        eq_(att_metadata['sha1'], calc_digest(StringIO('unascrittaperprovare'),
+                                                  algorithm='sha1'))

--- a/archivant/test/test_instantiation.py
+++ b/archivant/test/test_instantiation.py
@@ -1,0 +1,55 @@
+from archivant import Archivant
+from tempfile import mkdtemp
+from shutil import rmtree
+from elasticsearch import Elasticsearch
+from nose.tools import raises
+from urllib3.exceptions import LocationValueError
+
+
+TEST_ES_INDEX = 'test-archivant'
+FSDB_PATH_PREFIX = "archivant_test_"
+
+
+def cleanup(esIndex=None, tmpDir=None):
+    if esIndex is not None:
+        es = Elasticsearch()
+        es.indices.delete(esIndex)
+
+    if tmpDir is not None:
+        rmtree(tmpDir)
+
+
+def test_instantiation_ok():
+    tmpDir = mkdtemp(prefix=FSDB_PATH_PREFIX)
+    conf = {'ES_INDEXNAME': TEST_ES_INDEX,
+            'FSDB_PATH': tmpDir}
+    arc = Archivant(conf)
+    cleanup(esIndex=TEST_ES_INDEX, tmpDir=tmpDir)
+
+
+@raises(ValueError)
+def test_instantiation_no_fsdb():
+    conf = {'ES_INDEXNAME': TEST_ES_INDEX}
+    arc = Archivant(conf)
+
+
+@raises(ValueError)
+def test_instantiation_no_indexname():
+    tmpDir = mkdtemp(prefix=FSDB_PATH_PREFIX)
+    conf = {'FSDB_PATH': tmpDir}
+    try:
+        arc = Archivant(conf)
+    finally:
+        cleanup(tmpDir=tmpDir)
+
+
+@raises(LocationValueError)
+def test_instantiation_hosts_error():
+    tmpDir = mkdtemp(prefix=FSDB_PATH_PREFIX)
+    conf = {'ES_INDEXNAME': TEST_ES_INDEX,
+            'ES_HOSTS': "",
+            'FSDB_PATH': tmpDir}
+    try:
+        arc = Archivant(conf)
+    finally:
+        cleanup(tmpDir=tmpDir)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [nosetests]
 all-modules=1
 with-coverage=1
-cover-package=libreantdb,webant,presets
+cover-package=libreantdb, webant, presets, archivant

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(name='libreant',
       author_email='insomnialab@hacari.org',
       url='https://github.com/insomnia-lab/libreant',
       license='AGPL',
-      packages=['libreantdb', 'webant', 'presets'],
+      packages=['libreantdb', 'webant', 'presets', 'archivant'],
       install_requires=[
           'gevent',
           'elasticsearch',

--- a/webant/manage.py
+++ b/webant/manage.py
@@ -21,7 +21,7 @@ manager = Manager(app)
                 help='How many results to return. Defaults to all')
 def db_export(size):
     '''outputs an exportable version of the db'''
-    db = app.get_db()
+    db = app.archivant._db
     if int(size) < 0:
         size = len(db)
     for item in db.get_all_books(size=size)['hits']['hits']:
@@ -31,7 +31,7 @@ def db_export(size):
 @manager.command
 def db_item_export(item_id):
     '''exports a single item'''
-    db = app.get_db()
+    db = app.archivant._db
     book = db.get_book_by_id(item_id)
     print(json.dumps(book))
 
@@ -39,7 +39,7 @@ def db_item_export(item_id):
 @manager.command
 def db_search(query):
     '''query, just like you would do in a browser'''
-    db = app.get_db()
+    db = app.archivant._db
     res = db.user_search(query)['hits']['hits']
     for item in res:
         print(item['_id'])
@@ -53,7 +53,7 @@ def db_import(filename, language='it'):
         buf = sys.stdin
     else:
         buf = open(filename)
-    db = app.get_db()
+    db = app.archivant._db
     i = 0
     for line in buf:
         i += 1

--- a/webant/templates/details.html
+++ b/webant/templates/details.html
@@ -2,7 +2,7 @@
 {% import "bootstrap/fixes.html" as fixes %}
 
 {% block title %}
-Libreant | {{ book['title'] if 'title' in book else bookid }}
+Libreant | {{ volume['metadata']['title'] if 'title' in volume['metadata'] else volume['id'] }}
 {% endblock %}
 
 {% block navbar %}
@@ -14,20 +14,20 @@ Libreant | {{ book['title'] if 'title' in book else bookid }}
 
 <div class="container">
     <header class="page-header" style="margin-top:0px">
-	    <h1>{{ book['title'] if 'title' in book else bookid }}
-		    <small>{{ book['actors'] | sort | join(',') }}</small>
+	    <h1>{{ volume['metadata']['title'] if 'title' in volume['metadata'] else volume['id'] }}
+		    <small>{{ volume['metadata']['actors'] | sort | join(',') }}</small>
 	    </h1>
     </header>
-     {% if '_attachments' in book %}
-        {% for file in  book['_attachments'] %}
-             <a class="btn btn-default" href="{{ url_for('download_attachment', volumeID=bookid, attachmentID=file['id']) }}">
+     {% if (volume['attachments'] | length) > 0 %}
+        {% for attachment in volume['attachments'] %}
+             <a class="btn btn-default" href="{{ url_for('download_attachment', volumeID=volume['id'], attachmentID=attachment['id']) }}">
                 <div class="row" style="display: flex; align-items: center;">
                     <div class="col-xs-1">
                         <span class="glyphicon glyphicon glyphicon-download-alt" aria-hidden="true"></span>
                     </div>
                     <div class="col-xs-11">
-                        <strong>{{ file['name'] }}</strong>
-                        <p style="margin-bottom: 0px">{{ file['size'] | filesizeformat() }}</p>
+                        <strong>{{ attachment['metadata']['name'] }}</strong>
+                        <p style="margin-bottom: 0px">{{ attachment['metadata']['size'] | filesizeformat() }}</p>
                     </div>
                 </div>
              </a>
@@ -46,11 +46,11 @@ Libreant | {{ book['title'] if 'title' in book else bookid }}
 		        </tr>
 	        </thead>
 	        <tbody>
-	        {% for key in book %}
+	        {% for key in volume['metadata'] %}
                 {% if not key.startswith('_') %}
 	            <tr>
 		            <td>{{ key }}</td>
-		            <td>{{ book[key] }}</td>
+		            <td>{{ volume['metadata'][key] }}</td>
 	            </tr>
                 {% endif %}
 	        {% endfor %}
@@ -64,8 +64,8 @@ Libreant | {{ book['title'] if 'title' in book else bookid }}
 	        <tbody>
 		        {% for book in similar %}
 		        <tr>
-			        <td><a href="{{url_for('view_book',
-			        bookid=book['_id'])}}">
+			        <td><a href="{{url_for('view_volume',
+			        volumeID=book['_id'])}}">
 			        {{ book['_source']['title'] }}
 				        </a></td>
 			        <td>{{ book['_source']['actors'] | join(',') }}</td>

--- a/webant/templates/opens.xml
+++ b/webant/templates/opens.xml
@@ -15,7 +15,7 @@
     {% for b in books %}
      <item>
        <title>{{b['title']}}</title>
-       <link>{{url_for('view_book', bookid=b['_id'], _external=True)}}</link>
+       <link>{{url_for('view_volume', volumeID=b['_id'], _external=True)}}</link>
        <description>{{b['title']}}</description>
        <relevance:score>{{b['_score']}}</relevance:score>
      </item>

--- a/webant/templates/recents.html
+++ b/webant/templates/recents.html
@@ -71,7 +71,7 @@ header h1{
                     {% if 'actors' in b['_source'] %}
                     <li><span class="glyphicon glyphicon-user"></span> {{ b['_source']['actors'] | join(',')}}</li>
                     {% endif %}
-                    {% if '_attachments' in b['_source'] %}
+                    {% if (b['_source']['_attachments']|length) %}
                     <li><span class="glyphicon glyphicon-file"></span> {{ b['_source']['_attachments'] | length }}</li>
                     {% endif %}
                 </ul>

--- a/webant/templates/recents.html
+++ b/webant/templates/recents.html
@@ -45,14 +45,14 @@ header h1{
 
     <div id="item-list">
         {% for b in items %}
-        <div class="item-div row dyn-href" href="{{url_for('view_book', bookid=b['_id'])}}">
+        <div class="item-div row dyn-href" href="{{url_for('view_volume', volumeID=b['_id'])}}">
             <div class="item-thumbnail hidden-xs col-sm-1 vcenter">
-                <a href="{{url_for('view_book', bookid=b['_id'])}}">
+                <a href="{{url_for('view_volume', volumeID=b['_id'])}}">
 			        <span class="glyphicon glyphicon-book"></span>
 		        </a>
             </div>
             <div class="item-main col-xs-12 col-sm-7 vcenter">
-                <a class="item-title" href="{{url_for('view_book', bookid=b['_id'])}}"
+                <a class="item-title" href="{{url_for('view_volume', volumeID=b['_id'])}}"
                     {% if 'title' in b['_source'] %}
                         title="{{ b['_source']['title'] }}"> {{ b['_source']['title'] }}
                     {% else %}

--- a/webant/templates/search.html
+++ b/webant/templates/search.html
@@ -50,14 +50,14 @@ Libreant | {%trans%}Search{%endtrans%}: {{ query }}
 
     <div id="item-list">
         {% for b in books %}
-        <div class="item-div row dyn-href" href="{{url_for('view_book', bookid=b['_id'])}}">
+        <div class="item-div row dyn-href" href="{{url_for('view_volume', volumeID=b['_id'])}}">
             <div class="item-thumbnail hidden-xs col-sm-1 vcenter">
-                <a href="{{url_for('view_book', bookid=b['_id'])}}">
+                <a href="{{url_for('view_volume', volumeID=b['_id'])}}">
 			        <span class="glyphicon glyphicon-book"></span>
 		        </a>
             </div>
             <div class="item-main col-xs-12 col-sm-7 vcenter">
-                <a class="item-title" href="{{url_for('view_book', bookid=b['_id'])}}"
+                <a class="item-title" href="{{url_for('view_volume', volumeID=b['_id'])}}"
                     {% if 'title' in b %}
                         title="{{ b['title'] }}"> {{ b['title'] }}
                     {% else %}

--- a/webant/templates/search.html
+++ b/webant/templates/search.html
@@ -71,7 +71,7 @@ Libreant | {%trans%}Search{%endtrans%}: {{ query }}
                     {% if 'actors' in b %}
                     <li><span class="glyphicon glyphicon-user"></span> {{ b['actors'] | join(',')}}</li>
                     {% endif %}
-                    {% if '_attachments' in b %}
+                    {% if (b['_attachments']|length) > 0 %}
                     <li><span class="glyphicon glyphicon-file"></span> {{ b['_attachments'] | length }}</li>
                     {% endif %}
                 </ul>


### PR DESCRIPTION
This is the first pull-request aimed to introduce Archivant package inside libreant project.
Archivant is an implementation of a Data Access Layer, handling both an fsdb instance and a libreantdb one, this package exposes an API to operate on 'volumes'.
A 'volume' represents a physical/digital object stored within archivant.
Volumes are structured as described in `Archivant.normalize_volume`, these have metadata and a list of attachments.

This pull-request actually doesn't add new features but makes a lot of refractoring to move code and logic from webant end-point to archivant package.

Test:
 - standard nosetest tests have been added, so you can use the old fashion `python setup.py test`
 - we do not already have a simple way to test web UI. You could play around with web interface to ensure that all the old functionalities are still working.

If you like the new package architecture and you don't find any strange behaviour or regression we could proceed with merging.