### PR TITLE
[archivant] iteration over all volumes

### DIFF
--- a/archivant/archivant.py
+++ b/archivant/archivant.py
@@ -78,7 +78,7 @@ class Archivant():
         res['type'] = 'volume'
         res['id'] = volume['_id']
         if '_score' in volume:
-            res['score'] = volume['score']
+            res['score'] = volume['_score']
 
         source = volume['_source']
         attachments = source['_attachments']

--- a/archivant/archivant.py
+++ b/archivant/archivant.py
@@ -1,6 +1,8 @@
 import os
+
 from elasticsearch import Elasticsearch
 from elasticsearch import NotFoundError
+
 from uuid import uuid4
 from fsdb import Fsdb
 from fsdb.hashtools import calc_file_digest, calc_digest
@@ -137,6 +139,11 @@ class Archivant():
             return self._db.get_book_by_id(volumeID)
         except NotFoundError:
             raise NotFoundException("could not found volume with id: '{}'".format(volumeID))
+
+    def get_all_volumes(self):
+        '''iterate over all stored volumes'''
+        for raw_volume in self._db.iterate_all():
+            yield self.normalize_volume(raw_volume)
 
     def get_volume(self, volumeID):
         log.debug("Requested volume with id:'{}'".format(volumeID))

--- a/archivant/test/test_get_volume.py
+++ b/archivant/test/test_get_volume.py
@@ -14,3 +14,15 @@ class TestArchivantGetVolume(TestArchivant):
         volume_metadata = self.generate_volume_metadata()
         id = self.arc.insert_volume(volume_metadata)
         self.arc.get_volume(id)
+
+    def test_get_all_volumes(self):
+        n = 3
+        ids = list()
+        for _ in range(n):
+            id = self.arc.insert_volume(self.generate_volume_metadata())
+            ids.append(id)
+        self.arc._db.es.indices.refresh()
+        volumes = [ vol for vol in self.arc.get_all_volumes()]
+        for vol in volumes:
+            ok_(vol['id'] in ids)
+        eq_(len(volumes), len(ids))

--- a/libreantdb/api.py
+++ b/libreantdb/api.py
@@ -1,4 +1,5 @@
 from elasticsearch import NotFoundError
+from elasticsearch.helpers import scan
 
 import logging
 log = logging.getLogger(__name__)
@@ -151,6 +152,9 @@ class DB(object):
 
     def get_all_books(self, size=30):
         return self._search({}, size=size)
+
+    def iterate_all(self):
+        return scan(self.es, index=self.index_name)
 
     def get_last_inserted(self, size=30):
         query = {"fields": ["_timestamp", "_source"],

--- a/libreantdb/test/test_iterate.py
+++ b/libreantdb/test/test_iterate.py
@@ -1,0 +1,44 @@
+'''
+This module will connect to your elasticsearch instance.
+An index will be reserved to the tests.
+'''
+
+from nose.tools import ok_, eq_, with_setup
+
+from . import db, cleanall
+
+
+@with_setup(cleanall, cleanall)
+def test_iterate_all():
+    n = 5
+    ids = list()
+    for i in range(n):
+        id = db.add_book(body=dict(num=i, title='Un libro', _language='it'))['_id']
+        ids.append(id)
+    db.es.indices.refresh(index=db.index_name)
+    ret_ids = [b['_id'] for b in db.iterate_all()]
+    eq_(len(set(ids).symmetric_difference(ret_ids)), 0)
+
+
+@with_setup(cleanall, cleanall)
+def test_iterate_all_empty():
+    eq_(len([b for b in db.iterate_all()]), 0)
+
+
+@with_setup(cleanall, cleanall)
+def test_iterate_all_disturbed():
+    '''if you add elements after the iteration query
+       they should not compare in the results
+    '''
+    n = 5
+    ids = list()
+    for i in range(n):
+        id = db.add_book(body=dict(num=i, title='Un libro', _language='it'))['_id']
+        ids.append(id)
+    db.es.indices.refresh(index=db.index_name)
+    books = list()
+    for b in db.iterate_all():
+        db.add_book(body=dict(title='Un libro', _language='it'))
+        books.append(b)
+    ret_ids = [ b['_id'] for b in books]
+    eq_(len(set(ids).symmetric_difference(ret_ids)), 0)


### PR DESCRIPTION
the goal is provide a way to efficiently iterate over all volumes.

I've added a wrapper of `elasticsearch.helpers.scan` in `libreantdb`, that is exposed by archivant through `get_all_volumes()`. The results are normalized

The first commit is a stupid bug fix.