### PR TITLE
Api introduction

### DIFF
--- a/libreantdb/api.py
+++ b/libreantdb/api.py
@@ -126,8 +126,8 @@ class DB(object):
     def __len__(self):
         return self.es.count(index=self.index_name)['count']
 
-    def _search(self, body, size=30):
-        return self.es.search(index=self.index_name, body=body, size=size)
+    def _search(self, body, **kargs):
+        return self.es.search(index=self.index_name, body=body, **kargs)
 
     def _get_search_field(self, field, value):
         return {'query':
@@ -179,9 +179,9 @@ class DB(object):
     def get_book_by_id(self, id):
         return self.es.get(index=self.index_name, id=id)
 
-    def get_books_querystring(self, query):
+    def get_books_querystring(self, query, **kargs):
         q = {'query': query, 'fields': ['_text_*']}
-        return self._search({'query': dict(query_string=q)})
+        return self._search({'query': dict(query_string=q)}, **kargs)
 
     def user_search(self, query):
         '''

--- a/webant/api/blueprint_api.py
+++ b/webant/api/blueprint_api.py
@@ -36,3 +36,28 @@ def apiNotFound(invalid_path):
 def exceptionHandler(e):
     current_app.logger.exception(e)
     return apiErrorHandler(ApiError("internal server error", 500))
+
+
+@api.route('/volumes/<volumeID>', methods=['GET'])
+def get_volume(volumeID):
+    try:
+        volume = current_app.archivant.get_volume(volumeID)
+    except NotFoundException, e:
+        raise ApiError("volume not found", 404, details=str(e))
+    return jsonify({'data': volume})
+
+@api.route('/volumes/<volumeID>/attachments/', methods=['GET'])
+def get_attachments(volumeID):
+    try:
+        atts = current_app.archivant.get_volume(volumeID)['attachments']
+    except NotFoundException, e:
+        raise ApiError("volume not found", 404, details=str(e))
+    return jsonify({'data': atts})
+
+@api.route('/volumes/<volumeID>/attachments/<attachmentID>', methods=['GET'])
+def get_attachment(volumeID, attachmentID):
+    try:
+        att = current_app.archivant.get_attachment(volumeID, attachmentID)
+    except NotFoundException, e:
+        raise ApiError("attachment not found", 404, details=str(e))
+    return jsonify({'data': att})

--- a/webant/api/blueprint_api.py
+++ b/webant/api/blueprint_api.py
@@ -1,0 +1,38 @@
+from flask import Blueprint, current_app, jsonify
+from archivant.exceptions import NotFoundException
+
+
+class ApiError(Exception):
+    def __init__(self, message, http_code, err_code=None, details=None):
+        Exception.__init__(self, http_code, err_code, message, details)
+        self.http_code = http_code
+        self.err_code = err_code
+        self.message = message
+        self.details = details
+
+    def __str__(self):
+        return "http_code: {}, err_code: {}, message: '{}', details: '{}'".format(self.http_code, self.err_code, self.message, self.details)
+
+
+api = Blueprint('api', __name__)
+
+@api.errorhandler(ApiError)
+def apiErrorHandler(apiErr):
+    error = {}
+    error['code'] = apiErr.err_code if (apiErr.err_code is not None) else apiErr.http_code
+    error['message'] = apiErr.message
+    error['details'] = apiErr.details if (apiErr.details is not None) else ""
+
+    response = jsonify({'error': error})
+    response.status_code = apiErr.http_code
+    return response
+
+# workaround for "https://github.com/mitsuhiko/flask/issues/1498"
+@api.route("/<path:invalid_path>", methods=['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS'])
+def apiNotFound(invalid_path):
+    raise ApiError("invalid URI", 404)
+
+@api.errorhandler(Exception)
+def exceptionHandler(e):
+    current_app.logger.exception(e)
+    return apiErrorHandler(ApiError("internal server error", 500))

--- a/webant/api/blueprint_api.py
+++ b/webant/api/blueprint_api.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, current_app, jsonify
-from archivant.exceptions import NotFoundException
 
+from archivant.exceptions import NotFoundException
+from webant.utils import send_attachment_file
 
 class ApiError(Exception):
     def __init__(self, message, http_code, err_code=None, details=None):
@@ -61,3 +62,10 @@ def get_attachment(volumeID, attachmentID):
     except NotFoundException, e:
         raise ApiError("attachment not found", 404, details=str(e))
     return jsonify({'data': att})
+
+@api.route('/volumes/<volumeID>/attachments/<attachmentID>/file', methods=['GET'])
+def get_file(volumeID, attachmentID):
+    try:
+        return send_attachment_file(current_app.archivant, volumeID, attachmentID)
+    except NotFoundException, e:
+        raise ApiError("file not found", 404, details=str(e))

--- a/webant/utils.py
+++ b/webant/utils.py
@@ -1,5 +1,5 @@
 import functools
-
+from flask import send_file
 
 def memoize(obj):
     '''decorator to memoize things'''
@@ -36,3 +36,12 @@ def requestedFormat(request,acceptedFormat):
             return fieldFormat
         else:
             return request.accept_mimetypes.best_match(acceptedFormat)
+
+def send_attachment_file(archivant, volumeID, attachmentID):
+    f = archivant.get_file(volumeID, attachmentID)
+    attachment = archivant.get_attachment(volumeID, attachmentID)
+    archivant._db.increment_download_count(volumeID, attachmentID)
+    return send_file(f,
+                     mimetype=attachment['metadata']['mime'],
+                     attachment_filename=attachment['metadata']['name'],
+                     as_attachment=True)

--- a/webant/webant.py
+++ b/webant/webant.py
@@ -17,6 +17,7 @@ from constants import isoLangs
 from archivant import Archivant
 from archivant.exceptions import NotFoundException
 from agherant import agherant
+from api.blueprint_api import api
 from webserver_utils import gevent_run
 import config_utils
 
@@ -53,6 +54,7 @@ class LibreantViewApp(LibreantCoreApp):
         super(LibreantViewApp, self).__init__(import_name, defaults)
         if self.config['AGHERANT_DESCRIPTIONS']:
             self.register_blueprint(agherant, url_prefix='/agherant')
+        self.register_blueprint(api, url_prefix='/api/v1')
         Bootstrap(self)
         self.babel = Babel(self)
 

--- a/webant/webant.py
+++ b/webant/webant.py
@@ -2,9 +2,9 @@ import tempfile
 import logging
 import os
 
-from flask import Flask, render_template, request, abort, Response, redirect, url_for, send_file, make_response
+from flask import Flask, render_template, request, abort, Response, redirect, url_for, make_response
 from werkzeug import secure_filename
-from utils import requestedFormat
+from utils import requestedFormat, send_attachment_file
 from flask_bootstrap import Bootstrap
 from elasticsearch import exceptions as es_exceptions
 from flask.ext.babel import Babel, gettext
@@ -183,13 +183,7 @@ def create_app():
     @app.route('/download/<volumeID>/<attachmentID>')
     def download_attachment(volumeID, attachmentID):
         try:
-            attachment = app.archivant.get_attachment(volumeID, attachmentID)
-            file = app.archivant.get_file(volumeID, attachmentID)
-            app.archivant._db.increment_download_count(volumeID, attachmentID)
-            return send_file(file,
-                             mimetype=attachment['metadata']['mime'],
-                             attachment_filename=attachment['metadata']['name'],
-                             as_attachment=True)
+            return send_attachment_file(app.archivant, volumeID, attachmentID)
         except NotFoundException:
             # no attachment found with the given id
             return renderErrorPage(message='no attachment found with id "{}" on volume "{}"'.format(attachmentID, volumeID), httpCode=404)


### PR DESCRIPTION
Overview
------------
Api was implemented thanks to a blueprint module inside `webant`.

With this pr we are going to expose all `GET` functionalities provided by archivant.

The rest api are graph-organized:
 - search and get volumes (with pagination support): `/volumes/`
 - get specific volume: `/volumes/<volumeID>`
 - get all attachments of a volume: `/volumes/<volumeID>/attachments/`
 - get specific attachment: `/volumes/<volumeID>/attachments/<attachmentID>`
 - get file associated with an attachment: `/volumes/<volumeID>/attachments/<attachmentID>/file`

Errors
--------
The following is an error example:
```json
{
  "error": {
    "code": 404, 
    "message": "volume not found",
    "details": "could not found volume with id: 'not666not'"
  }
}
```
Testing
----------
the blueprint is registered at `/api/v1`
to start you can try with `/api/v1/volumes/`

To be done
---------------
 - documentation
 - expose all other functionalities provided by archivant.