### PR TITLE
API add/update implementation

### DIFF
--- a/archivant/archivant.py
+++ b/archivant/archivant.py
@@ -1,5 +1,5 @@
 import os
-
+from numbers import Integral
 from elasticsearch import Elasticsearch
 from elasticsearch import NotFoundError
 
@@ -318,6 +318,14 @@ class Archivant():
         for k in metadata.keys():
             if k not in modifiable_fields:
                 raise ValueError('Not modifiable field given: {}'.format(k))
+        if 'name' in metadata and not isinstance(metadata['name'], basestring):
+            raise ValueError("'name' must be a string")
+        if 'mime' in metadata and not isinstance(metadata['mime'], basestring):
+            raise ValueError("'mime' must be a string")
+        if 'notes' in metadata and not isinstance(metadata['notes'], basestring):
+            raise ValueError("'notes' must be a string")
+        if 'download_count' in metadata and not isinstance(metadata['download_count'], Integral):
+            raise ValueError("'download_count' must be a number")
         rawVolume = self._req_raw_volume(volumeID)
         for attachment in rawVolume['_source']['_attachments']:
             if attachment['id'] == attachmentID:

--- a/archivant/archivant.py
+++ b/archivant/archivant.py
@@ -189,14 +189,17 @@ class Archivant():
         if not attachments:
            return
         rawVolume = self._req_raw_volume(volumeID)
+        attsID = list()
         for index, a in enumerate(attachments):
             try:
                 rawAttachment = self._assemble_attachment(a['file'], a)
                 rawVolume['_source']['_attachments'].append(rawAttachment)
+                attsID.append(rawAttachment['id'])
             except:
                 log.exception("Error while elaborating attachments array at index: {}".format(index))
                 raise
         self._db.modify_book(volumeID, rawVolume['_source'], version=rawVolume['_version'])
+        return attsID
 
     def insert_volume(self, metadata, attachments=[]):
         '''Insert a new volume

--- a/archivant/test/test_attachment_ops.py
+++ b/archivant/test/test_attachment_ops.py
@@ -10,17 +10,22 @@ class TestArchivantAttachmentOperations(TestArchivant):
         volume_metadata = self.generate_volume_metadata()
         volumeID = self.arc.insert_volume(volume_metadata)
         attachments = self.generate_attachments(1)
-        self.arc.insert_attachments(volumeID, attachments)
+        attsID = self.arc.insert_attachments(volumeID, attachments)
+        eq_(len(attsID), 1)
         added_attachments = self.arc.get_volume(volumeID)['attachments']
         eq_(len(added_attachments), 1)
+        eq_(added_attachments[0]['id'], attsID[0])
 
     def test_insert_attachments(self, n=4):
         volume_metadata = self.generate_volume_metadata()
         volumeID = self.arc.insert_volume(volume_metadata)
         attachments = self.generate_attachments(n)
-        self.arc.insert_attachments(volumeID, attachments)
+        attsID = self.arc.insert_attachments(volumeID, attachments)
+        eq_(len(attsID), 4)
         added_attachments = self.arc.get_volume(volumeID)['attachments']
-        eq_(len(added_attachments), n)
+        addedAttsID = [a['id'] for a in added_attachments]
+        eq_(len(addedAttsID), n)
+        eq_(len(set(attsID).symmetric_difference(addedAttsID)), 0)
 
     def test_insert_attachments_burst(self, n=4):
         volume_metadata = self.generate_volume_metadata()

--- a/webant/api/blueprint_api.py
+++ b/webant/api/blueprint_api.py
@@ -85,6 +85,19 @@ def add_volume():
     response.headers['Location'] = link_self
     return response
 
+
+@api.route('/volumes/<volumeID>', methods=['PUT'])
+def update_volume(volumeID):
+    metadata = receive_volume_metadata()
+    try:
+        current_app.archivant.update_volume(volumeID, metadata)
+    except NotFoundException, e:
+        raise ApiError("volume not found", 404, details=str(e))
+    except ValueError, e:
+        raise ApiError("malformed metadata", 400, details=str(e))
+    return make_success_response("volume successfully updated", 201)
+
+
 @api.route('/volumes/<volumeID>', methods=['GET'])
 def get_volume(volumeID):
     try:

--- a/webant/api/blueprint_api.py
+++ b/webant/api/blueprint_api.py
@@ -171,6 +171,17 @@ def delete_attachment(volumeID, attachmentID):
         raise ApiError("attachment not found", 404, details=str(e))
     return make_success_response("attachment has been successfully deleted")
 
+
+@api.route('/volumes/<volumeID>/attachments/<attachmentID>', methods=['PUT'])
+def update_attachment(volumeID, attachmentID):
+    metadata = receive_metadata()
+    try:
+        current_app.archivant.update_attachment(volumeID, attachmentID, metadata)
+    except ValueError, e:
+        raise ApiError("malformed request", 400, details=str(e))
+    return make_success_response("attachment has been successfully updated")
+
+
 @api.route('/volumes/<volumeID>/attachments/<attachmentID>/file', methods=['GET'])
 def get_file(volumeID, attachmentID):
     try:


### PR DESCRIPTION
These commits will complete the core of the application public interface.

We now have all [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) operation for managing volumes and attachments.

#### TODO
 - We don't have API documentation yet. #168 
 - automatic tests for REST API.