### PR TITLE
176 metadata only

### DIFF
--- a/archivant/exceptions.py
+++ b/archivant/exceptions.py
@@ -1,2 +1,6 @@
 class NotFoundException(Exception):
     pass
+
+
+class FileOpNotSupported(Exception):
+    pass

--- a/archivant/test/test_instantiation.py
+++ b/archivant/test/test_instantiation.py
@@ -1,4 +1,5 @@
 from archivant import Archivant
+from archivant.exceptions import FileOpNotSupported
 from tempfile import mkdtemp
 from shutil import rmtree
 from elasticsearch import Elasticsearch
@@ -27,10 +28,11 @@ def test_instantiation_ok():
     cleanup(esIndex=TEST_ES_INDEX, tmpDir=tmpDir)
 
 
-@raises(ValueError)
+@raises(FileOpNotSupported)
 def test_instantiation_no_fsdb():
     conf = {'ES_INDEXNAME': TEST_ES_INDEX}
     arc = Archivant(conf)
+    arc._fsdb
 
 
 @raises(ValueError)

--- a/webant/templates/add.html
+++ b/webant/templates/add.html
@@ -100,7 +100,7 @@ Libreant | {%trans%}Add new{%endtrans%} {{ preset.id if preset else "item"}}
         
             <br>
 
-            {% if not preset or preset.allow_upload %}
+            {% if file_upload and ( not preset or preset.allow_upload ) %}
             <div id="files-div">
                 <div id="files-array"></div>
                 

--- a/webant/webant.py
+++ b/webant/webant.py
@@ -136,8 +136,8 @@ def create_app(conf):
                 preset = app.presetManager.presets[reqPreset]
         else:
             preset = None
-
-        return render_template('add.html', preset=preset, availablePresets=app.presetManager.presets, isoLangs=isoLangs)
+        file_upload = app.archivant.is_file_op_supported()
+        return render_template('add.html', file_upload=file_upload, preset=preset, availablePresets=app.presetManager.presets, isoLangs=isoLangs)
 
     @app.route('/description.xml')
     def description():


### PR DESCRIPTION
make possible to use archivant without using fsdb.
In metadata-only mode all archivant function
will raise FileOpNotSupported exception.

To operate in metadata-only mode you need to not set the
FSDB_PATH parameter.