### PR TITLE
FIX strong dependency on elasticsearch

### DIFF
--- a/archivant/archivant.py
+++ b/archivant/archivant.py
@@ -50,10 +50,16 @@ class Archivant():
         # initialize elasticsearch
         if not self._config['ES_INDEXNAME']:
             raise ValueError('ES_INDEXNAME cannot be empty')
-        db = DB(Elasticsearch(hosts=self._config['ES_HOSTS']),
-                index_name=self._config['ES_INDEXNAME'])
-        db.setup_db()
-        self._db = db
+        self.__db = None
+
+    @property
+    def _db(self):
+        if self.__db is None:
+            db = DB(Elasticsearch(hosts=self._config['ES_HOSTS']),
+                    index_name=self._config['ES_INDEXNAME'])
+            db.setup_db()
+            self.__db = db
+        return self.__db
 
     @property
     def _fsdb(self):

--- a/archivant/test/test_instantiation.py
+++ b/archivant/test/test_instantiation.py
@@ -2,9 +2,8 @@ from archivant import Archivant
 from archivant.exceptions import FileOpNotSupported
 from tempfile import mkdtemp
 from shutil import rmtree
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, ElasticsearchException
 from nose.tools import raises
-from urllib3.exceptions import LocationValueError
 
 
 TEST_ES_INDEX = 'test-archivant'
@@ -14,7 +13,8 @@ FSDB_PATH_PREFIX = "archivant_test_"
 def cleanup(esIndex=None, tmpDir=None):
     if esIndex is not None:
         es = Elasticsearch()
-        es.indices.delete(esIndex)
+        if es.indices.exists(esIndex):
+            es.indices.delete(esIndex)
 
     if tmpDir is not None:
         rmtree(tmpDir)
@@ -45,13 +45,27 @@ def test_instantiation_no_indexname():
         cleanup(tmpDir=tmpDir)
 
 
-@raises(LocationValueError)
 def test_instantiation_hosts_error():
+    '''this should not raise errors'''
     tmpDir = mkdtemp(prefix=FSDB_PATH_PREFIX)
     conf = {'ES_INDEXNAME': TEST_ES_INDEX,
-            'ES_HOSTS': "",
+            'ES_HOSTS': "127.0.0.1:12345",
             'FSDB_PATH': tmpDir}
     try:
         Archivant(conf)
+    finally:
+        cleanup(tmpDir=tmpDir)
+
+
+@raises(ElasticsearchException)
+def test_instantiation_hosts_error_on_query():
+    '''explicitly doing queries will raise error'''
+    tmpDir = mkdtemp(prefix=FSDB_PATH_PREFIX)
+    conf = {'ES_INDEXNAME': TEST_ES_INDEX,
+            'ES_HOSTS': "127.0.0.1:12345",
+            'FSDB_PATH': tmpDir}
+    try:
+        arc = Archivant(conf)
+        arc.get_volume('whatever')
     finally:
         cleanup(tmpDir=tmpDir)


### PR DESCRIPTION
Now libreant can be started with elasticsearch still not ready,
providing limited functionality. This makes init systems happier.

Seems that there is no issue for this, but we discussed this "privately".
I did only minor tests, so I'm asking for a "real" review: don't merge blindly because it "just seems okay" please!