### PR TITLE
Insert-volume/ feature in libreant-db cli

### DIFF
--- a/archivant/exceptions.py
+++ b/archivant/exceptions.py
@@ -4,3 +4,7 @@ class NotFoundException(Exception):
 
 class FileOpNotSupported(Exception):
     pass
+
+class UploadError(Exception):
+    pass
+

--- a/archivant/exceptions.py
+++ b/archivant/exceptions.py
@@ -4,7 +4,3 @@ class NotFoundException(Exception):
 
 class FileOpNotSupported(Exception):
     pass
-
-class UploadError(Exception):
-    pass
-

--- a/cli/libreant_db.py
+++ b/cli/libreant_db.py
@@ -4,6 +4,7 @@ import json
 
 from archivant import Archivant
 from archivant.exceptions import NotFoundException
+from archivant.exceptions import UploadError
 from conf import config_utils
 from conf.defaults import get_def_conf, get_help
 from utils.loggers import initLoggers
@@ -16,7 +17,7 @@ arc = None
 
 @click.group(name="libreant-db", help="command line program to manage libreant database")
 @click.version_option()
-@click.option('-s', '--settings', type=click.Path(exists=True, readable=True), help='file from wich load settings')
+@click.option('-s', '--settings', type=click.Path(exists=True, readable=True), help='file from which load settings')
 @click.option('-d', '--debug', is_flag=True, help=get_help('DEBUG'))
 @click.option('--fsdb-path', type=click.Path(), metavar="<path>", help=get_help('FSDB_PATH'))
 @click.option('--es-indexname', type=click.STRING, metavar="<name>", help=get_help('ES_INDEXNAME'))
@@ -94,6 +95,32 @@ def export_all(pretty):
     volumes = [vol for vol in arc.get_all_volumes()]
     click.echo(json.dumps(volumes, indent=indent))
 
+@libreant_db.command(name='upload-volume', help='uploads a volume to the db')
+@click.option('-l', '--language', type=click.Choice(['en','it']), help='specify the language of the media you are going to upload')
+@click.option('-f', '--filepath', type=click.Path(exists=True,resolve_path=True),help='the path to the media to be uploaded')
+@click.option('-n', '--name', type=click.STRING, help='[optional] name of the media including the extension')
+@click.option('-m', '--mime', type=click.STRING, help='[optional] mime type of the media')
+@click.option('-n', '--notes', type=click.STRING, help='[optional] notes about the media')
+@click.option('-x', '--extravalues', type=click.STRING, help='[optional] additional parameters')
+def upload_volume(language,filepath,name,mime,notes,extravalues):
+    def check_extra_values(x_values):
+        raise(NotImplemented)
+    #if len(extravalues)>0:
+    #    check_extra_values(extravalues)
+    #else:
+    #    pass
+    metadata={"_language":language}
+    attachments=[{"file":filepath}]
+    if name:
+        attachments[0]['name']=name
+    if mime:
+        attachments[0]['mime']=mime
+    if notes:
+        attachments[0]['notes']=notes
+    try:
+        arc.insert_volume(metadata,attachments)
+    except UploadError('An upload error have occurred!') as e:
+        click.secho(str(e), fg="yellow", err=True)
 
 if __name__ == '__main__':
     libreant_db()


### PR DESCRIPTION
Hi.
I've tried to add the insert-volume/append-file feature to the cli utility libreant-db.
Now there are two more subcommands defined:
 - libreant-db insert-volume
 - libreant-db append-file

The first one uploads a volume to the selected libreant instance and (optionally)
appends files (repeating the same flags is correctly treated as a multiple file upload).
The second one appends a (list of) file(s) to a given existing volume.