### PR TITLE
every package we provide is documented

### DIFF
--- a/doc/source/api/archivant.rst
+++ b/doc/source/api/archivant.rst
@@ -1,0 +1,22 @@
+archivant package
+=================
+
+.. automodule:: archivant
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Submodules
+----------
+
+.. automodule:: archivant.archivant
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: archivant.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/doc/source/api/conf.rst
+++ b/doc/source/api/conf.rst
@@ -1,0 +1,22 @@
+conf package
+============
+
+.. automodule:: conf
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Submodules
+----------
+
+.. automodule:: conf.config_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: conf.defaults
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+

--- a/doc/source/api/modules.rst
+++ b/doc/source/api/modules.rst
@@ -1,7 +1,11 @@
 API
-=============
+===
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 1
 
+   archivant
+   conf
    libreantdb
+   presets
+   users

--- a/doc/source/api/presets.rst
+++ b/doc/source/api/presets.rst
@@ -1,7 +1,7 @@
-libreantdb package
-==================
+presets package
+===============
 
-.. automodule:: libreantdb
+.. automodule:: presets
     :members:
     :undoc-members:
     :show-inheritance:
@@ -9,7 +9,7 @@ libreantdb package
 Submodules
 ----------
 
-.. automodule:: libreantdb.api
+.. automodule:: presets.presetManager
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api/users.rst
+++ b/doc/source/api/users.rst
@@ -1,0 +1,22 @@
+users package
+=============
+
+.. automodule:: users
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Submodules
+----------
+
+.. automodule:: users.api
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: users.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+


### PR DESCRIPTION
This is created using 
```bash
sphinx-apidoc -EM -H libreant . -o doc/source/api -d1 webant/ utils/ *.py cli/ */test/
```
plus some cleaning (removing doctests from generated files).

While it creates some unwanted sections (like empty _Subpackages_ and _Submodules_) the output is quite good, and I like how "reproducible it is" using `sphinx-apidoc`, which makes adding new packages to documentation easy.

To test it, you must run `python setup.py build_sphinx` and then `firefox build/sphinx/html/index.html`

What you should find is a much extended `API` section, which now contains every package we ship. Of course, not everything is properly documented, and the fact that the API generation was missing for so much time means that some docstring is not formatted as expected. I won't fix those bugs in this pull request.