### PR TITLE
Removed unique constraint on capability model

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -34,11 +34,12 @@ class Capability(BaseModel):
         you can use :class:`Action` class to compose the bitmask
     """
 
+    id = PrimaryKeyField()
     domain = CharField()
     action = IntegerField()
 
     class Meta:
-        indexes = ((('domain', 'action'), True),)
+        indexes = ((('domain', 'action'), False),)
 
     @classmethod
     def simToReg(self, sim):

--- a/webant/test/api/test_api_capabilities.py
+++ b/webant/test/api/test_api_capabilities.py
@@ -36,9 +36,7 @@ class TestApiCapabilities(WebantTestApiCase):
     def test_add_capability_same_name(self):
         capData = {'domain':'/res1/id1/res2/*', 'actions':['READ','UPDATE']}
         self.add_capability(capData)
-        with self.assertRaises(ApiClientError) as ace:
-            self.add_capability(capData)
-            eq_(ace.res.status_code, 409)
+        self.add_capability(capData)
 
     def test_get_capability(self):
         capData = {'domain':'res1/id1/res2/*', 'actions':['READ','UPDATE']}


### PR DESCRIPTION
the couple (domain, action) is not unique anymore

I also explicitly added the ID field to capability model

fixes #206