### PR TITLE
Travis doc build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - elasticsearch
 
 install:
-  - "pip install flake8"
+  - "pip install flake8 sphinx"
   - "python setup.py install"
 
 before_script:
@@ -16,3 +16,4 @@ before_script:
 script:
   - 'flake8'
   - python setup.py test
+  - "python setup.py build_sphinx"


### PR DESCRIPTION
These two commits will run `python setup.py build_sphinx` during the travis test process.

The first commit accomplishes the goal in a single run; the second creates a "build matrix" which makes the different tests parallelizable and more "to the point" (ie: sphinx and flake8 are not installed when running unit tests)

refs #212 