### PR TITLE
User CLI

### DIFF
--- a/cli/libreant_users.py
+++ b/cli/libreant_users.py
@@ -201,7 +201,11 @@ def list_capabilities(groupname):
     click.echo(json.dumps([c.to_dict() for c in group.capabilities]))
 
 
-@group_subcmd.command(name='cap-add', help='Add a new capability to a group')
+@group_subcmd.command(name='cap-add',
+                      short_help='Add a new capability to a group',
+                      help='Add a new capability to a group\n\n'
+                      'An action is expressed as a subset of the string "CRUD"\n'
+                      'Examples of valid values are R,CR,CRUD,CD,etc.')
 @click.argument('groupname')
 @click.argument('domain')
 @click.argument('action')

--- a/cli/libreant_users.py
+++ b/cli/libreant_users.py
@@ -1,0 +1,226 @@
+import click
+import logging
+import json
+
+import users.api
+import users
+
+from conf import config_utils
+from conf.defaults import get_def_conf, get_help
+from utils.loggers import initLoggers
+
+usersDB = None
+conf = dict()
+
+
+@click.group(name="libreant-users", help="manage libreant users")
+@click.version_option()
+@click.option('-s', '--settings', type=click.Path(exists=True, readable=True), help='file from wich load settings')
+@click.option('-d', '--debug', is_flag=True, help=get_help('DEBUG'))
+@click.option('--users-db', type=click.Path(), metavar="<url>", help=get_help('USERS_DATABASE') )
+def libreant_users(debug, settings, users_db):
+    initLoggers(logNames=['config_utils'])
+    global conf
+    conf = config_utils.load_configs('LIBREANT_', defaults=get_def_conf(), path=settings)
+    cliConf = {}
+    if debug:
+        cliConf['DEBUG'] = True
+    if users_db:
+        cliConf['USERS_DATABASE'] = users_db
+    conf.update(cliConf)
+    initLoggers(logging.DEBUG if conf.get('DEBUG', False) else logging.WARNING)
+
+    global usersDB
+    usersDB = users.init_db(conf['USERS_DATABASE'],
+                               pwd_salt_size=conf['PWD_SALT_SIZE'],
+                               pwd_rounds=conf['PWD_ROUNDS'])
+    users.populate_with_defaults()
+
+
+@libreant_users.group(name='user')
+def user_subcmd():
+    pass
+
+
+@user_subcmd.command(name='add')
+@click.argument('username')
+def user_add(username):
+    try:
+        users.api.get_user(name=username)
+    except users.api.NotFoundException:
+        pass
+    else:
+        click.secho('User already present', err=True)
+        exit(1)
+    password = click.prompt('Password', hide_input=True,
+                            confirmation_prompt=True)
+    user = users.api.add_user(username, password)
+    click.echo(json.dumps(user.to_dict()))
+
+
+@user_subcmd.command(name='list')
+@click.option('--password', is_flag=True, help='Show also password (in hashed form)')
+def user_list(password):
+    if password:
+        all_users = [{'name': u.name, 'id': u.id, 'pwd_hash': u.pwd_hash} for u in users.User.select()]
+    else:
+        all_users = [{'name': u.name, 'id': u.id} for u in users.User.select()]
+    click.echo(json.dumps(all_users))
+
+
+@user_subcmd.command(name='show')
+@click.argument('username')
+def user_show(username):
+    u = users.api.get_user(name=username)
+    data = u.to_dict()
+    data['groups'] = [g.to_dict() for g in u.groups]
+    click.echo(json.dumps(data))
+
+
+@user_subcmd.command(name='passwd', help='change the password for a user')
+@click.argument('username')
+def user_set_password(username):
+    try:
+        user = users.api.get_user(name=username)
+    except users.api.NotFoundException:
+        click.secho('Cannot find user "%s"' % username, err=True)
+        exit(1)
+
+    password = click.prompt('Password', hide_input=True,
+                            confirmation_prompt=True)
+    users.api.update_user(user.id, {'password': password})
+
+
+@user_subcmd.command(name='check-password',
+                        help='check if a password is correct')
+@click.argument('username')
+def user_check_password(username):
+    try:
+        user = users.api.get_user(name=username)
+    except users.api.NotFoundException:
+        click.secho('Cannot find user "%s"' % username, err=True)
+        exit(1)
+
+    password = click.prompt('Password', hide_input=True,
+                            confirmation_prompt=False)
+    if user.verify_password(password):
+        click.secho('Password correct', fg='green')
+    else:
+        click.secho('Incorrect password for "%s"' % username,
+                    fg='red', err=True)
+
+
+@user_subcmd.command(name='delete')
+@click.argument('username')
+def user_del(username):
+    u = users.api.get_user(name=username)
+    users.api.delete_user(u.id)
+
+
+@libreant_users.group(name='group')
+def group_subcmd():
+    pass
+
+
+@group_subcmd.command(name='delete')
+@click.argument('groupname')
+def group_del(groupname):
+    u = users.api.get_group(name=groupname)
+    users.api.delete_group(u.id)
+
+
+@group_subcmd.command(name='create')
+@click.argument('groupname')
+def group_add(groupname):
+    try:
+        users.api.get_group(name=groupname)
+    except users.api.NotFoundException:
+        pass
+    else:
+        click.secho('Group already present', err=True)
+        exit(1)
+    group = users.api.add_group(groupname)
+    click.echo(json.dumps(group.to_dict()))
+
+
+@group_subcmd.command(name='list', help='List groups')
+def list_groups():
+    click.echo(json.dumps([g.to_dict() for g in users.Group.select()]))
+
+
+@group_subcmd.command(name='show', help='Show group properties and members')
+@click.argument('groupname')
+def show_group(groupname):
+    group = users.api.get_group(name=groupname)
+    groupdict = group.to_dict()
+    groupdict['users'] = [u.to_dict() for u in users.api.get_users_in_group(group.id)]
+    click.echo(json.dumps(groupdict))
+
+
+@group_subcmd.command(name='user-remove', help='Remove a user from a group')
+@click.argument('username')
+@click.argument('groupname')
+def remove_from_group(username, groupname):
+    u = users.api.get_user(name=username)
+    g = users.api.get_group(name=groupname)
+    users.api.remove_user_from_group(u.id, g.id)
+    userdata = u.to_dict()
+    userdata['groups'] = [ug.to_dict() for ug in
+                          users.api.get_groups_of_user(u.id)]
+    click.echo(json.dumps(userdata))
+
+
+@group_subcmd.command(name='user-add', help='Add a user to a group')
+@click.argument('username')
+@click.argument('groupname')
+def add_to_group(username, groupname):
+    u = users.api.get_user(name=username)
+    g = users.api.get_group(name=groupname)
+    users.api.add_user_to_group(u.id, g.id)
+    userdata = u.to_dict()
+    userdata['groups'] = [ug.to_dict() for ug in users.api.get_groups_of_user(u.id)]
+    click.echo(json.dumps(userdata))
+
+
+@libreant_users.group(name='capability')
+def caps_subcmd():
+    pass
+
+
+@group_subcmd.command(name='cap-list', help='List capabilities owned by group')
+@click.argument('groupname')
+def list_capabilities(groupname):
+    group = users.api.get_group(name=groupname)
+    click.echo(json.dumps([c.to_dict() for c in group.capabilities]))
+
+
+@group_subcmd.command(name='cap-add', help='Add a new capability to a group')
+@click.argument('groupname')
+@click.argument('domain')
+@click.argument('action')
+def capability_add(groupname, domain, action):
+    possibleactions = {v[0]: v for v in users.Action.ACTIONS}
+    action = '' if action == '0' else action
+    action = [possibleactions[x] for x in action]
+    action = users.Action.from_list(action)
+
+    group = users.api.get_group(name=groupname)
+    cap = users.api.add_capability(domain, action)
+    users.api.add_capability_to_group(cap.id, group.id)
+
+    group = users.api.get_group(name=groupname)
+    groupdata = group.to_dict()
+    groupdata['capabilities'] = [c.to_dict() for c in group.capabilities]
+    click.echo(json.dumps(groupdata))
+
+
+@caps_subcmd.command(name='delete')
+@click.argument('capID')
+def capability_del(capid):
+    users.api.delete_capability(capid)
+
+
+@caps_subcmd.command(name='list', help='List every capability')
+def capability_list():
+    allcaps = users.Capability.select()
+    click.echo(json.dumps([c.to_dict() for c in allcaps]))

--- a/cli/libreant_users.py
+++ b/cli/libreant_users.py
@@ -13,6 +13,11 @@ usersDB = None
 conf = dict()
 
 
+def die(msg, exit_code=1):
+        click.secho('ERROR: ' + msg, err=True, fg='red')
+        exit(exit_code)
+
+
 @click.group(name="libreant-users", help="manage libreant users")
 @click.version_option()
 @click.option('-s', '--settings', type=click.Path(exists=True, readable=True), help='file from wich load settings')
@@ -28,6 +33,8 @@ def libreant_users(debug, settings, users_db):
     if users_db:
         cliConf['USERS_DATABASE'] = users_db
     conf.update(cliConf)
+    if conf['USERS_DATABASE'] is None:
+        die('--users-db not set')
     initLoggers(logging.DEBUG if conf.get('DEBUG', False) else logging.WARNING)
 
     global usersDB

--- a/cli/tests/test_libreant_users.py
+++ b/cli/tests/test_libreant_users.py
@@ -1,0 +1,27 @@
+import os.path
+
+from click.testing import CliRunner
+
+from cli.libreant_users import libreant_users
+
+
+def get_runner():
+    runner = CliRunner()
+    runner.isolation(env={})
+    return runner
+
+
+def test_usersdb_mandatory():
+    result = get_runner().invoke(libreant_users, ['user', 'list'])
+    assert result.exit_code != 0
+    assert '--users-db' in result.output
+
+
+def test_usersdb_works():
+    runner = get_runner()
+    with runner.isolated_filesystem():
+        assert not os.path.exists('u.db')
+        base = ['--users-db', 'sqlite:///u.db', 'user']
+        result = runner.invoke(libreant_users, base +['list'])
+        assert os.path.exists('u.db')
+        assert result.exit_code == 0

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ conf = dict(
         entry_points={'console_scripts': [
           'libreant=cli.libreant:libreant',
           'agherant=cli.agherant:agherant',
+          'libreant-users=cli.libreant_users:libreant_users',
           'libreant-db=cli.libreant_db:libreant_db'
         ]},
         classifiers=[

--- a/users/models.py
+++ b/users/models.py
@@ -12,6 +12,16 @@ GroupToCapabilityProxy = Proxy()
 UserToGroupProxy = Proxy()
 
 
+class ActionField(IntegerField):
+    db_field = 'action'
+
+    def db_value(self, value):
+        return value
+
+    def python_value(self, value):
+        return Action(value)
+
+
 class BaseModel(Model):
     class Meta:
         database = db_proxy  # Use proxy for our DB.
@@ -39,7 +49,7 @@ class Capability(BaseModel):
 
     id = PrimaryKeyField()
     domain = CharField()
-    action = IntegerField()
+    action = ActionField()
 
     class Meta:
         indexes = ((('domain', 'action'), False),)
@@ -76,7 +86,7 @@ class Capability(BaseModel):
         return self.match_domain(dom) and self.match_action(act)
 
 
-class Action():
+class Action(int):
     """Actions utiliy class
 
     You can use this class attributes to compose the actions bitmask::
@@ -92,23 +102,27 @@ class Action():
     # the index of the action in the list correspond to the its position in the bitmask
     ACTIONS = ['CREATE', 'READ', 'UPDATE', 'DELETE']
 
-    @classmethod
-    def bitmask_to_list(cls, bitmask):
+    def __new__(cls, bitmask):
+        if bitmask >= 2**len(cls.ACTIONS):
+            raise ValueError('bitmask %d is too big' % bitmask)
+        return super(Action, cls).__new__(cls, bitmask)
+
+    def to_list(self):
         '''convert an actions bitmask into a list of action strings'''
         res = []
-        for a in cls.ACTIONS:
-            aBit = cls.action_bitmask(a)
-            if ((bitmask & aBit) == aBit):
+        for a in self.__class__.ACTIONS:
+            aBit = self.__class__.action_bitmask(a)
+            if ((self & aBit) == aBit):
                 res.append(a)
         return res
 
     @classmethod
-    def list_to_bitmask(cls, actions):
+    def from_list(cls, actions):
         '''convert list of actions into the corresponding bitmask'''
         bitmask = 0
         for a in actions:
             bitmask |= cls.action_bitmask(a)
-        return bitmask
+        return Action(bitmask)
 
     @classmethod
     def action_bitmask(cls, action):
@@ -192,7 +206,7 @@ class GroupToCapability(BaseModel):
     capability = ForeignKeyField(Capability, on_delete='CASCADE')
 
     class Meta:
-            primary_key = CompositeKey('group', 'capability')
+        primary_key = CompositeKey('group', 'capability')
 
 
 class UserToGroup(BaseModel):
@@ -200,7 +214,8 @@ class UserToGroup(BaseModel):
     group = ForeignKeyField(Group, on_delete='CASCADE')
 
     class Meta:
-            primary_key = CompositeKey('user', 'group')
+        primary_key = CompositeKey('user', 'group')
+
 
 GroupToCapabilityProxy.initialize(GroupToCapability)
 UserToGroupProxy.initialize(UserToGroup)

--- a/users/models.py
+++ b/users/models.py
@@ -16,6 +16,9 @@ class BaseModel(Model):
     class Meta:
         database = db_proxy  # Use proxy for our DB.
 
+    def to_dict(self):
+        return dict(id=self.id)
+
 
 class Capability(BaseModel):
     """Capability model
@@ -40,6 +43,9 @@ class Capability(BaseModel):
 
     class Meta:
         indexes = ((('domain', 'action'), False),)
+
+    def to_dict(self):
+        return dict(id=self.id, domain=self.domain, action=self.action.to_list())
 
     @classmethod
     def simToReg(self, sim):
@@ -124,6 +130,9 @@ class Group(BaseModel):
     name = CharField(unique=True)
     capabilities = ManyToManyField(Capability, related_name='groups', through_model=GroupToCapabilityProxy)
 
+    def to_dict(self):
+        return dict(id=self.id, name=self.name)
+
     def can(self, domain, action):
         for cap in self.capabilities:
             if(cap.match(domain, action)):
@@ -144,6 +153,9 @@ class User(BaseModel):
             self.name = kargs['name']
         if 'password' in kargs:
             self.set_password(kargs['password'])
+
+    def to_dict(self):
+        return dict(id=self.id, name=self.name)
 
     def set_password(self, password):
         """set user password

--- a/users/test/test_capability.py
+++ b/users/test/test_capability.py
@@ -55,6 +55,11 @@ class TestCapability(TestBaseClass):
         eq_(usr.capabilities.get(), caps[1])
         eq_(GroupToCapability.select().count(), 1)
 
+    def test_action_creation(self):
+        Action.from_list(Action.ACTIONS)
+        with self.assertRaises(ValueError):
+            Action(Action.from_list(Action.ACTIONS) + 1)
+
     def test_action_matching(self):
         cap = Capability.create(domain='s',
                                 action=(Action.CREATE | Action.READ | Action.UPDATE))
@@ -121,4 +126,4 @@ class TestCapability(TestBaseClass):
         self.assertFalse(grp.can('users/123', Action.UPDATE))
 
     def test_bitmask(self):
-        self.assertEqual(Action.bitmask_to_list(Action.list_to_bitmask(Action.ACTIONS)), Action.ACTIONS)
+        self.assertEqual(Action.from_list(Action.ACTIONS).to_list(), Action.ACTIONS)

--- a/webant/api/users_api.py
+++ b/webant/api/users_api.py
@@ -156,7 +156,7 @@ def get_capability(capID):
     return jsonify({'data':
                       {'id': cap.id,
                        'domain': Capability.regToSim(cap.domain),
-                       'actions': Action.bitmask_to_list(cap.action)}})
+                       'actions': cap.action.to_list()}})
 
 
 @route('/capabilities/<int:capID>', methods=['DELETE'])
@@ -181,7 +181,7 @@ def add_capability():
     if not actions:
         raise ApiError("Bad Request", 400, details="missing 'actions' parameter")
     try:
-        cap = users.api.add_capability(domain=domain, action=Action.list_to_bitmask(actions))
+        cap = users.api.add_capability(domain=domain, action=Action.from_list(actions))
     except users.api.ConflictException, e:
         raise ApiError("Conflict", 409, details=str(e))
     link_self = url_for('.get_capability', capID=cap.id, _external=True)
@@ -198,7 +198,7 @@ def update_capability(capID):
         raise ApiError("Unsupported media type", 415)
     updates = request.json
     if 'actions' in updates:
-        updates['action'] = Action.list_to_bitmask(updates.pop('actions'))
+        updates['action'] = Action.from_list(updates.pop('actions'))
     try:
         users.api.update_capability(capID, updates)
     except users.api.NotFoundException, e:


### PR DESCRIPTION
This fixes #77. It provides a new command `libreant-users` which provides several command to manage users. I think there is every action possibly needed for administering users.

The output style is, similarly to `libreant-db`, outputting a JSON representation of the "interested" object. So for example when you create a user, the user object will be printed.

The first commit extend the models, so now there is a specific `ActionField` which makes action handling easier. Also, every model now has a `to_dict()` method.

I remember that the choice of both naming and goal of this method was debated, and I am not sure that I remember it correctly. So please point out what I'd better change, if so.