### PR TITLE
Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,30 @@
 language: python
 
-python:
-  - "2.7"
-
 services:
   - elasticsearch
 
-env:
-  - VERSION_GEVENT="1.0.1"
-  - VERSION_GEVENT="1.0.2"
-  - VERSION_GEVENT="1.1.0"
+matrix:
+    include:
+        - python: "2.7"
+          env: TEST_SUITE=test VERSION_GEVENT=1.0.1
+        - python: "2.7"
+          env: TEST_SUITE=test VERSION_GEVENT=1.0.2
+        - python: "2.7"
+          env: TEST_SUITE=test VERSION_GEVENT=1.1.0
+        - python: "2.7"
+          env: TEST_SUITE=build_sphinx
+        - python: "2.7"
+          env: TEST_SUITE=flake
 
 before_install:
-  - pip install --force gevent==$VERSION_GEVENT
-
+    - '[[ -n $VERSION_GEVENT ]] && pip install --force gevent==$VERSION_GEVENT || true'
 
 install:
-  - pip install flake8 sphinx
-  - python setup.py install
-
-before_script:
-  - sleep 10 # wait for elasticsearch
+    - 'if [[ $TEST_SUITE == flake ]]; then pip install flake8; return $? ; fi'
+    - 'if [[ $TEST_SUITE != flake ]]; then python setup.py install; return $? ; fi'
+    - 'if [[ $TEST_SUITE == build_sphinx ]]; then pip install sphinx; return $? ; fi'
 
 script:
-  - flake8
-  - python setup.py test
-  - python setup.py build_sphinx
+    - 'if [[ $TEST_SUITE == flake ]]; then flake8; return $?; fi'
+    - 'if [[ $TEST_SUITE == test ]]; then sleep 10 && python setup.py test ; return $?; fi'
+    - 'if [[ $TEST_SUITE == build_sphinx ]]; then python setup.py build_sphinx; return $?; fi'


### PR DESCRIPTION
Creates a "build matrix" which makes the different tests parallelizable and more "to the point" (ie: sphinx and flake8 are not installed when running unit tests)

refs #212 