### PR TITLE
use exit code on libreant cli

### DIFF
--- a/cli/libreant.py
+++ b/cli/libreant.py
@@ -58,6 +58,7 @@ def libreant(settings, debug, port, address, fsdb_path, es_indexname, es_hosts, 
             raise
         else:
             click.secho(str(e), fg='yellow', err=True)
+            exit(1)
 
 if __name__ == '__main__':
     libreant()


### PR DESCRIPTION
On exception the exit code will be 1.

Due to the reloader on debug mode the command will not exit, but it will print
the exception and the relative stack trace

fixes #230