### PR TITLE
Do not ignore exception while reading configuration file

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,5 +1,17 @@
 import click
+import sys
 from conf.config_utils import load_configs
+
+
+def die(msg, exit_code=1, error=True):
+    ce = click.ClickException(click.style(msg, fg='red'))
+    ce.exit_code = exit_code
+    raise ce
+
+
+def bye(msg, exit_code=1, fg='yellow'):
+    click.secho(msg, fg=fg)
+    sys.exit(exit_code)
 
 
 def load_cfg(path, envvar_prefix='LIBREANT_', debug=False):
@@ -10,4 +22,4 @@ def load_cfg(path, envvar_prefix='LIBREANT_', debug=False):
         if debug:
             raise
         else:
-            raise click.ClickException(click.style(str(e), fg='red'))
+            die(str(e))

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,13 @@
+import click
+from conf.config_utils import load_configs
+
+
+def load_cfg(path, envvar_prefix='LIBREANT_', debug=False):
+    '''wrapper of config_utils.load_configs'''
+    try:
+        return load_configs(envvar_prefix, path=path)
+    except Exception as e:
+        if debug:
+            raise
+        else:
+            raise click.ClickException(click.style(str(e), fg='red'))

--- a/cli/agherant.py
+++ b/cli/agherant.py
@@ -17,7 +17,8 @@ from custom_types import StringList
 @click.option('--agherant-descriptions', type=StringList(), metavar="<url>..", help=get_help('AGHERANT_DESCRIPTIONS'))
 def agherant(settings, debug, port, address, agherant_descriptions):
     initLoggers(logNames=['config_utils'])
-    conf = config_utils.load_configs('LIBREANT_', defaults=get_def_conf(), path=settings)
+    conf = get_def_conf()
+    conf.update(config_utils.load_configs('LIBREANT_', path=settings))
     cliConf = {}
     if debug:
         cliConf['DEBUG'] = True

--- a/cli/agherant.py
+++ b/cli/agherant.py
@@ -1,7 +1,7 @@
 import click
 import logging
 
-from conf import config_utils
+from . import load_cfg
 from conf.defaults import get_def_conf, get_help
 from utils.loggers import initLoggers
 from webant.agherant_standalone import main
@@ -18,7 +18,7 @@ from custom_types import StringList
 def agherant(settings, debug, port, address, agherant_descriptions):
     initLoggers(logNames=['config_utils'])
     conf = get_def_conf()
-    conf.update(config_utils.load_configs('LIBREANT_', path=settings))
+    conf.update(load_cfg(settings, debug=debug))
     cliConf = {}
     if debug:
         cliConf['DEBUG'] = True
@@ -37,6 +37,7 @@ def agherant(settings, debug, port, address, agherant_descriptions):
             raise
         else:
             click.secho(str(e), fg='yellow', err=True)
+            exit(1)
 
 if __name__ == '__main__':
     agherant()

--- a/cli/libreant.py
+++ b/cli/libreant.py
@@ -2,7 +2,7 @@ import click
 import logging
 import json
 
-from conf import config_utils
+from . import load_cfg
 from conf.defaults import get_def_conf, get_help
 from utils.loggers import initLoggers
 from webant.webant import main
@@ -25,7 +25,7 @@ from custom_types import StringList
 def libreant(settings, debug, port, address, fsdb_path, es_indexname, es_hosts, users_db, preset_paths, agherant_descriptions, dump_settings):
     initLoggers(logNames=['config_utils'])
     conf = get_def_conf()
-    conf.update(config_utils.load_configs('LIBREANT_', path=settings))
+    conf.update(load_cfg(settings, debug=debug))
     cliConf = {}
     if debug:
         cliConf['DEBUG'] = True

--- a/cli/libreant.py
+++ b/cli/libreant.py
@@ -2,7 +2,7 @@ import click
 import logging
 import json
 
-from . import load_cfg
+from . import load_cfg, die
 from conf.defaults import get_def_conf, get_help
 from utils.loggers import initLoggers
 from webant.webant import main
@@ -58,8 +58,8 @@ def libreant(settings, debug, port, address, fsdb_path, es_indexname, es_hosts, 
         if conf.get('DEBUG', False):
             raise
         else:
-            click.secho(str(e), fg='yellow', err=True)
-            exit(1)
+            die(str(e))
+
 
 if __name__ == '__main__':
     libreant()

--- a/cli/libreant.py
+++ b/cli/libreant.py
@@ -24,7 +24,8 @@ from custom_types import StringList
 @click.option('--dump-settings', is_flag=True, help='dump current settings and exit')
 def libreant(settings, debug, port, address, fsdb_path, es_indexname, es_hosts, users_db, preset_paths, agherant_descriptions, dump_settings):
     initLoggers(logNames=['config_utils'])
-    conf = config_utils.load_configs('LIBREANT_', defaults=get_def_conf(), path=settings)
+    conf = get_def_conf()
+    conf.update(config_utils.load_configs('LIBREANT_', path=settings))
     cliConf = {}
     if debug:
         cliConf['DEBUG'] = True

--- a/cli/libreant_db.py
+++ b/cli/libreant_db.py
@@ -4,9 +4,9 @@ import json
 import os
 import mimetypes
 
+from . import load_cfg
 from archivant import Archivant
 from archivant.exceptions import NotFoundException
-from conf import config_utils
 from conf.defaults import get_def_conf, get_help
 from utils.loggers import initLoggers
 from custom_types import StringList
@@ -27,7 +27,7 @@ def libreant_db(debug, settings, fsdb_path, es_indexname, es_hosts):
     initLoggers(logNames=['config_utils'])
     global conf
     conf = get_def_conf()
-    conf.update(config_utils.load_configs('LIBREANT_', path=settings))
+    conf.update(load_cfg(settings, debug=debug))
     cliConf = {}
     if debug:
         cliConf['DEBUG'] = True

--- a/cli/libreant_db.py
+++ b/cli/libreant_db.py
@@ -4,7 +4,7 @@ import json
 import os
 import mimetypes
 
-from . import load_cfg
+from . import load_cfg, die, bye
 from archivant import Archivant
 from archivant.exceptions import NotFoundException
 from conf.defaults import get_def_conf, get_help
@@ -47,8 +47,7 @@ def libreant_db(debug, settings, fsdb_path, es_indexname, es_hosts):
         if conf.get('DEBUG', False):
             raise
         else:
-            click.secho(str(e), fg='yellow', err=True)
-            exit(1)
+            die(str(e))
 
 
 @libreant_db.command(name="export-volume", help="export a volume")
@@ -58,8 +57,7 @@ def export_volume(volumeid, pretty):
     try:
         volume = arc.get_volume(volumeid)
     except NotFoundException as e:
-        click.secho(str(e), fg="yellow", err=True)
-        exit(4)
+        bye(str(e), exit_code=4)
 
     indent = 3 if pretty else None
     ouput = json.dumps(volume, indent=indent)
@@ -72,8 +70,7 @@ def delete_volume(volumeid):
     try:
         arc.delete_volume(volumeid)
     except NotFoundException as e:
-        click.secho(str(e), fg="yellow", err=True)
-        exit(4)
+        bye(str(e), exit_code=4)
 
 
 @libreant_db.command(help="search volumes by query")
@@ -83,8 +80,7 @@ def search(query, pretty):
     results = arc._db.user_search(query)['hits']['hits']
     results = map(arc.normalize_volume, results)
     if not results:
-        click.secho("No results found for '{}'".format(query), fg="yellow", err=True)
-        exit(4)
+        bye("No results found for '{}'".format(query), exit_code=4)
     indent = 3 if pretty else None
     output = json.dumps(results, indent=indent)
     click.echo(output)
@@ -107,8 +103,7 @@ def append_file(volumeid, filepath, notes):
     try:
         arc.insert_attachments(volumeid,attachments)
     except:
-        click.secho('An upload error occurred in updating an attachment!',fg='yellow', err=True)
-        exit(4)
+        die('An upload error occurred in updating an attachment!', exit_code=4)
 
 
 @libreant_db.command(name='insert-volume')
@@ -155,8 +150,7 @@ def insert_volume(language, filepath, notes, metadata):
     try:
         out = arc.insert_volume(meta,attachments)
     except:
-        click.secho('An upload error have occurred!', fg="yellow", err=True)
-        exit(4)
+        die('An upload error have occurred!', exit_code=4)
     click.echo(out)
 
 
@@ -170,7 +164,7 @@ def attach_list(filepaths, notes):
 
     # this if clause means "if those lists are not of the same length"
     if len(filepaths) != len(notes):
-        raise click.ClickException('The number of --filepath, and --notes must be the same')
+        die('The number of --filepath, and --notes must be the same')
 
     attach_list = []
     for fname, note in zip(filepaths, notes):

--- a/cli/libreant_db.py
+++ b/cli/libreant_db.py
@@ -26,7 +26,8 @@ arc = None
 def libreant_db(debug, settings, fsdb_path, es_indexname, es_hosts):
     initLoggers(logNames=['config_utils'])
     global conf
-    conf = config_utils.load_configs('LIBREANT_', defaults=get_def_conf(), path=settings)
+    conf = get_def_conf()
+    conf.update(config_utils.load_configs('LIBREANT_', path=settings))
     cliConf = {}
     if debug:
         cliConf['DEBUG'] = True

--- a/cli/libreant_users.py
+++ b/cli/libreant_users.py
@@ -5,7 +5,7 @@ import json
 import users.api
 import users
 
-from conf import config_utils
+from . import load_cfg
 from conf.defaults import get_def_conf, get_help
 from utils.loggers import initLoggers
 
@@ -34,7 +34,7 @@ def libreant_users(debug, settings, users_db, pretty):
     initLoggers(logNames=['config_utils'])
     global conf
     conf = get_def_conf()
-    conf.update(config_utils.load_configs('LIBREANT_', path=settings))
+    conf.update(load_cfg(settings, debug=debug))
     cliConf = {}
     if debug:
         cliConf['DEBUG'] = True

--- a/cli/libreant_users.py
+++ b/cli/libreant_users.py
@@ -33,7 +33,8 @@ def die(msg, exit_code=1):
 def libreant_users(debug, settings, users_db, pretty):
     initLoggers(logNames=['config_utils'])
     global conf
-    conf = config_utils.load_configs('LIBREANT_', defaults=get_def_conf(), path=settings)
+    conf = get_def_conf()
+    conf.update(config_utils.load_configs('LIBREANT_', path=settings))
     cliConf = {}
     if debug:
         cliConf['DEBUG'] = True

--- a/cli/libreant_users.py
+++ b/cli/libreant_users.py
@@ -5,7 +5,7 @@ import json
 import users.api
 import users
 
-from . import load_cfg
+from . import load_cfg, die, bye
 from conf.defaults import get_def_conf, get_help
 from utils.loggers import initLoggers
 
@@ -17,11 +17,6 @@ conf = dict()
 def pretty_json_dumps(*args, **kargs):
     kargs['indent'] = 3
     return json.dumps(*args, **kargs)
-
-
-def die(msg, exit_code=1):
-        click.secho('ERROR: ' + msg, err=True, fg='red')
-        exit(exit_code)
 
 
 @click.group(name="libreant-users", help="manage libreant users")
@@ -42,7 +37,7 @@ def libreant_users(debug, settings, users_db, pretty):
         cliConf['USERS_DATABASE'] = users_db
     conf.update(cliConf)
     if conf['USERS_DATABASE'] is None:
-        die('--users-db not set')
+        die('Error: --users-db not set')
     if pretty:
         global json_dumps
         json_dumps = pretty_json_dumps
@@ -58,7 +53,7 @@ def libreant_users(debug, settings, users_db, pretty):
         if conf['DEBUG']:
             raise
         else:
-            die(str(e))
+            die('Error: ' + str(e))
 
 
 class ExistingUserType(click.ParamType):
@@ -135,9 +130,9 @@ def user_check_password(user):
     password = click.prompt('Password', hide_input=True,
                             confirmation_prompt=False)
     if user.verify_password(password):
-        click.secho('Password correct', fg='green')
+        bye('Password correct', fg='green', exit_code=0)
     else:
-        click.secho('Incorrect password', fg='red', err=True)
+        bye('Incorrect password', fg='red', exit_code=1)
 
 
 @user_subcmd.command(name='delete', help='Delete a user')

--- a/conf/config_utils.py
+++ b/conf/config_utils.py
@@ -7,16 +7,12 @@ log = getLogger('config_utils')
 
 
 def from_file(fname):
-    if not os.path.exists(fname):
-        log.warning('config file does not exist: "{}"'.format(fname))
-        return {}
     try:
         with open(fname) as buf:
             conf = json.load(buf)
             return conf
-    except Exception:
-        log.warning('Error loading config file', exc_info=1)
-        return {}
+    except EnvironmentError as ee:
+        raise Exception('Cannot read configuration file: {0} [{1}]'.format(fname, ee.strerror))
 
 
 def from_envvar_file(envvar, environ=None):

--- a/conf/config_utils.py
+++ b/conf/config_utils.py
@@ -11,6 +11,9 @@ def from_file(fname):
         with open(fname) as buf:
             conf = json.load(buf)
             return conf
+    except ValueError as ve:
+        log.error('Bad json format on conf file: "{0}"; {1}'.format(fname, str(ve)))
+        raise ve
     except EnvironmentError as ee:
         raise Exception('Cannot read configuration file: {0} [{1}]'.format(fname, ee.strerror))
 

--- a/conf/config_utils.py
+++ b/conf/config_utils.py
@@ -74,11 +74,10 @@ def from_envvars(prefix=None, environ=None, envvars=None, as_json=True):
     return conf
 
 
-def load_configs(envvar_prefix, defaults=None, path=None):
+def load_configs(envvar_prefix, path=None):
     '''Load configuration
 
     The following steps will be undertake:
-        * if `defaults` is provided, defaults are loded.
         * It will attempt to load configs from file:
           if `path` is provided, it will be used, otherwise the path
           will be taken from envvar `envvar_prefix` + "SETTINGS".
@@ -86,8 +85,6 @@ def load_configs(envvar_prefix, defaults=None, path=None):
 
     '''
     conf = {}
-    if defaults:
-        conf.update(defaults)
     if path:
         conf.update(from_file(path))
     else:

--- a/conf/test/test_config.py
+++ b/conf/test/test_config.py
@@ -92,11 +92,11 @@ def test_file_variable_notset():
     eq_(conf, {})
 
 
+@raises(Exception)
 def test_file_notexist():
-    '''if config file does not exist, it is ignored'''
-    conf = from_envvar_file('MYRC',
-                            environ={'MYRC': '/tmp/notexist.webant.test'})
-    eq_(conf, {})
+    '''if config file does not exist an exception should be raised'''
+    from_envvar_file('MYRC',
+                     environ={'MYRC': '/tmp/notexist.webant.test'})
 
 
 def test_file_exist():

--- a/conf/test/test_config.py
+++ b/conf/test/test_config.py
@@ -99,6 +99,21 @@ def test_file_notexist():
                      environ={'MYRC': '/tmp/notexist.webant.test'})
 
 
+@raises(ValueError)
+def test_file_wrong_format():
+    '''if config file has bad json fomat an exception should be raised'''
+    tempFd, tempPath = mkstemp(suffix='.json', prefix='webant_test',
+                               text=True)
+    try:
+        with os.fdopen(tempFd, 'w') as f:
+            f.write('not in json format $%^&*(, ')
+
+        from_envvar_file('MYRC',
+                         environ={'MYRC': tempPath})
+    finally:
+        os.unlink(tempPath)
+
+
 def test_file_exist():
     '''if config file exists, it is parsed as json'''
     tempfd, temppath = mkstemp(suffix='.json', prefix='webant_test',


### PR DESCRIPTION
Except for some cleanup and refactoring the main change is bring by the second commit, and it should fix #255.

It does not matter how the configuration file path is given (env, cli option, etc...), if there is an error while opening that file, an exception is raised.
The cli will print the stack trace if in debug mode otherwise it will print a colored one-line message.

There are no test on cli side, so please make some manual test.