### PR TITLE
grant read capability to volumes to anonymous user by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Libreant changelog
 ===================
 
+Next release
+++++++++++++
+- Changed default capability for anonynous (non logged) user: now she can read all volumes
+  in the collection.
+
+  Tip: if you have an existing and alredy initialized user database, it won't be changed, i.e.
+  if you upgrade from a previous version of libreant and you have existing users, the anonymous
+  user won't get the read capability.
+  In the case you want to add this capability to the already existing anonymous user you can use the
+  following command::
+
+    libreant-users --users-db <users-db-url> group cap-add anonymous "volumes/*" R
+
 0.4
 +++
 

--- a/users/__init__.py
+++ b/users/__init__.py
@@ -100,6 +100,9 @@ def populate_with_defaults():
     if not User.select().where(User.name == 'anonymous').exists():
         anon = User.create(name='anonymous', password='')
         anons = Group.create(name='anonymous')
+        readCap = Capability.create(domain=Capability.simToReg('/volumes/*'),
+                                    action=Action.READ)
+        anons.capabilities.add(readCap)
         anon.groups.add(anons)
         anon.save()
 

--- a/webant/test/api/test_api_capabilities.py
+++ b/webant/test/api/test_api_capabilities.py
@@ -54,7 +54,7 @@ class TestApiCapabilities(WebantTestApiCase):
         eq_(r.status_code, 200)
 
     def test_delete_capability_not_exists(self):
-        r = self.wtc.delete(self.CAP_URI + str(2))
+        r = self.wtc.delete(self.CAP_URI + str(1032))
         eq_(r.status_code, 404)
 
     def test_update_capability(self):


### PR DESCRIPTION
It seems that this is the most common scenario.