### PR TITLE
Tests and users api cleanup

### DIFF
--- a/webant/api/blueprint_api.py
+++ b/webant/api/blueprint_api.py
@@ -5,30 +5,33 @@ from archivant_api import routes as archivantRoutes
 from users_api import routes as usersRoutes
 
 
-api = Blueprint('api', __name__)
-add_routes(api, archivantRoutes)
-add_routes(api, usersRoutes)
+def get_blueprint_api(archivant_routes=True,
+                      users_routes=True):
+    api = Blueprint('api', __name__)
+    if archivant_routes:
+        add_routes(api, archivantRoutes)
+    if users_routes:
+        add_routes(api, usersRoutes)
 
+    @api.errorhandler(ApiError)
+    def apiErrorHandler(apiErr):
+        error = {}
+        error['code'] = apiErr.err_code if (apiErr.err_code is not None) else apiErr.http_code
+        error['message'] = apiErr.message
+        error['details'] = apiErr.details if (apiErr.details is not None) else ""
 
-@api.errorhandler(ApiError)
-def apiErrorHandler(apiErr):
-    error = {}
-    error['code'] = apiErr.err_code if (apiErr.err_code is not None) else apiErr.http_code
-    error['message'] = apiErr.message
-    error['details'] = apiErr.details if (apiErr.details is not None) else ""
+        response = jsonify({'error': error})
+        response.status_code = apiErr.http_code
+        return response
 
-    response = jsonify({'error': error})
-    response.status_code = apiErr.http_code
-    return response
+    # workaround for "https://github.com/mitsuhiko/flask/issues/1498"
+    @api.route("/<path:invalid_path>", methods=['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS'])
+    def apiNotFound(invalid_path):
+        raise ApiError("invalid URI", 404)
 
+    @api.errorhandler(Exception)
+    def exceptionHandler(e):
+        current_app.logger.exception(e)
+        return apiErrorHandler(ApiError("internal server error", 500))
 
-# workaround for "https://github.com/mitsuhiko/flask/issues/1498"
-@api.route("/<path:invalid_path>", methods=['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS'])
-def apiNotFound(invalid_path):
-    raise ApiError("invalid URI", 404)
-
-
-@api.errorhandler(Exception)
-def exceptionHandler(e):
-    current_app.logger.exception(e)
-    return apiErrorHandler(ApiError("internal server error", 500))
+    return api

--- a/webant/test/__init__.py
+++ b/webant/test/__init__.py
@@ -1,13 +1,39 @@
 import unittest
+from elasticsearch import Elasticsearch
+
 from webant import create_app
 from conf.defaults import get_def_conf
 
 
 class WebantTestCase(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         conf = get_def_conf()
-        conf['USERS_DATABASE'] = "sqlite:///:memory:"
-        conf['PWD_ROUNDS'] = 1
-        conf['TESTING'] = True
-        self.wtc = create_app(conf).test_client()
+        conf.update({
+            'TESTING': True,
+            'ES_INDEXNAME': 'webant_test',
+        })
+        cls.conf = conf
+
+    @classmethod
+    def tearDownClass(cls):
+        es = Elasticsearch()
+        es.indices.delete(cls.conf['ES_INDEXNAME'], ignore=[404])
+
+    @property
+    def wtc(self):
+        if not getattr(self, '_wtc', None):
+            self._wtc = create_app(self.conf).test_client()
+        return self._wtc
+
+
+class WebantUsersTestCase(WebantTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(WebantUsersTestCase, cls).setUpClass()
+        cls.conf.update({
+             'PWD_ROUNDS': 1,
+             'USERS_DATABASE': 'sqlite:///:memory:'
+        })

--- a/webant/test/api/__init__.py
+++ b/webant/test/api/__init__.py
@@ -1,8 +1,8 @@
-from webant.test import WebantTestCase
+from webant.test import WebantUsersTestCase
 from flask.json import loads, dumps
 
 
-class WebantTestApiCase(WebantTestCase):
+class WebantTestApiCase(WebantUsersTestCase):
 
     API_PREFIX = '/api/v1'
 

--- a/webant/test/test_main_routes.py
+++ b/webant/test/test_main_routes.py
@@ -18,3 +18,12 @@ class WebantMainRoutes(WebantTestCase):
 
     def test_recents(self):
         eq_(self.wtc.get('/recents').status_code, 200)
+
+    def test_do_add(self):
+        rv = self.wtc.post('/add',
+                      data=dict(
+                          _language='en',
+                          field_title='I am a canary',
+                      ), follow_redirects=True)
+        eq_(rv.status_code, 200)
+        assert 'I am a canary' in rv.data

--- a/webant/test/test_main_routes.py
+++ b/webant/test/test_main_routes.py
@@ -1,32 +1,20 @@
-from webant import create_app
-from conf.defaults import get_def_conf
+from . import WebantTestCase
 from nose.tools import eq_
 
 
-def get_wtc():
-    return create_app(get_def_conf()).test_client()
+class WebantMainRoutes(WebantTestCase):
 
+    def test_home(self):
+        eq_(self.wtc.get('/').status_code, 200)
 
-def test_home():
-    wtc = get_wtc()
-    eq_(wtc.get('/').status_code, 200)
+    def test_get_add(self):
+        eq_(self.wtc.get('/add').status_code, 200)
 
+    def test_empty_search(self):
+        eq_(self.wtc.get('/search?q=*').status_code, 200)
 
-def test_get_add():
-    wtc = get_wtc()
-    eq_(wtc.get('/add').status_code, 200)
+    def test_descr(self):
+        eq_(self.wtc.get('/description.xml').status_code, 200)
 
-
-def test_empty_search():
-    wtc = get_wtc()
-    eq_(wtc.get('/search?q=*').status_code, 200)
-
-
-def test_descr():
-    wtc = get_wtc()
-    eq_(wtc.get('/description.xml').status_code, 200)
-
-
-def test_recents():
-    wtc = get_wtc()
-    eq_(wtc.get('/recents').status_code, 200)
+    def test_recents(self):
+        eq_(self.wtc.get('/recents').status_code, 200)

--- a/webant/test/test_users_routes.py
+++ b/webant/test/test_users_routes.py
@@ -1,0 +1,28 @@
+from . import WebantTestCase, WebantUsersTestCase
+
+
+class TestSingleUserMode(WebantTestCase):
+    '''those tests express the behavior when no USERS_DATABASE is supplied'''
+
+    def test_no_login(self):
+        self.assertEqual(self.wtc.get('/login').status_code, 404)
+
+    def test_no_logout(self):
+        self.assertEqual(self.wtc.get('/logout').status_code, 404)
+
+    def test_no_users(self):
+        res = self.wtc.get('/api/v1/users/1')
+        self.assertEqual(res.status_code, 404)
+
+    def test_no_groups(self):
+        res = self.wtc.get('/api/v1/groups/1')
+        self.assertEqual(res.status_code, 404)
+
+
+class TestUsersMode(WebantUsersTestCase):
+
+    def test_login_pages(self):
+        self.assertEqual(self.wtc.get('/login').status_code, 200)
+        res = self.wtc.get('/logout')
+        self.assertEqual(res.status_code, 400)
+        assert 'not logged' in res.data

--- a/webant/webant.py
+++ b/webant/webant.py
@@ -16,7 +16,7 @@ from util import requestedFormat, send_attachment_file
 from archivant import Archivant
 from archivant.exceptions import NotFoundException, FileOpNotSupported
 from agherant import agherant
-from api.blueprint_api import api
+from api.blueprint_api import get_blueprint_api
 from webserver_utils import gevent_run
 import users
 import util
@@ -76,6 +76,7 @@ class LibreantViewApp(LibreantCoreApp):
         super(LibreantViewApp, self).__init__(import_name, defaults)
         if self.config['AGHERANT_DESCRIPTIONS']:
             self.register_blueprint(agherant, url_prefix='/agherant')
+        api = get_blueprint_api(users_routes=self.users_enabled)
         self.register_blueprint(api, url_prefix=self.config['API_URL'])
         Bootstrap(self)
         self.babel = Babel(self)


### PR DESCRIPTION
As asked by @boyska I've started to adjust #258, but I've realized that some bigger changes must be put in place. Thus this PR should be considered as a replacement of #258.

It operate on two major issue:

### Webant tests index name
Some tests were working on the default `libreant` index and they did not delete it after they've finished.

Now the `WebantTestCase` class make use of a temporary index that will be deeleted at the end of the class level tests.

Moreover now it's easier to subclass the `WebantTestCase` class.
As you can see in the `WebantUsersTestCase` class it is possible to use the `setUpClass` method to override the webant configuration that are going to be use during the tests.

### Single-user mode cleanup

In the case users are not enabled, users routes are not registered neither on the rest api. This means that all the endpoints related to the rest api about users stuff will return 404 when on single-user mode
