### PR TITLE
Added testing mode in libreantdb

### DIFF
--- a/archivant/archivant.py
+++ b/archivant/archivant.py
@@ -36,7 +36,8 @@ class Archivant():
         defaults = {
             'FSDB_PATH': None,
             'ES_HOSTS': None,
-            'ES_INDEXNAME': None
+            'ES_INDEXNAME': None,
+            'TESTING': False
         }
         defaults.update(conf)
         self._config = defaults
@@ -57,7 +58,8 @@ class Archivant():
     def _db(self):
         if self.__db is None:
             db = DB(Elasticsearch(hosts=self._config['ES_HOSTS']),
-                    index_name=self._config['ES_INDEXNAME'])
+                    index_name=self._config['ES_INDEXNAME'],
+                    testing=self._config['TESTING'])
             db.setup_db()
             self.__db = db
         return self.__db

--- a/archivant/test/class_template.py
+++ b/archivant/test/class_template.py
@@ -23,7 +23,8 @@ class TestArchivant():
     def setUp(self):
         self.tmpDir = mkdtemp(prefix=self.FSDB_PATH_PREFIX)
         conf = {'ES_INDEXNAME': self.TEST_ES_INDEX,
-                'FSDB_PATH': self.tmpDir}
+                'FSDB_PATH': self.tmpDir,
+                'TESTING': True}
         self.arc = Archivant(conf)
 
     def tearDown(self):

--- a/libreantdb/api.py
+++ b/libreantdb/api.py
@@ -75,11 +75,12 @@ class DB(object):
         }
     '''
     # Setup {{{2
-    def __init__(self, es, index_name):
+    def __init__(self, es, index_name, testing=False):
         self.es = es
         self.index_name = index_name
         # book_validator can adjust the book, and raise if it's not valid
         self.book_validator = validate_book
+        self.testing = testing
 
     def setup_db(self, wait_for_ready=True):
         ''' Create and configure index
@@ -137,6 +138,10 @@ class DB(object):
                 }
             }
         }}
+
+        if self.testing:
+            settings.update({"number_of_shards": 1,
+                             "number_of_replicas": 0})
 
         if not self.es.indices.exists(self.index_name):
             self.es.indices.create(index=self.index_name,

--- a/libreantdb/test/__init__.py
+++ b/libreantdb/test/__init__.py
@@ -3,7 +3,7 @@ from elasticsearch import Elasticsearch
 
 
 es = Elasticsearch()
-db = DB(es, index_name='test-book')
+db = DB(es, index_name='test-book', testing=True)
 
 
 def setUpPackage():

--- a/webant/webant.py
+++ b/webant/webant.py
@@ -34,7 +34,8 @@ class LibreantCoreApp(Flask):
             'ES_INDEXNAME': 'libreant',
             'USERS_DATABASE': "",
             'PWD_ROUNDS': None,
-            'PWD_SALT_SIZE': None
+            'PWD_SALT_SIZE': None,
+            'TESTING': False,
         }
         defaults.update(conf)
         self.config.update(defaults)
@@ -45,7 +46,7 @@ class LibreantCoreApp(Flask):
         '''
         self._logger = getLogger(self.import_name)
 
-        self.archivant = Archivant(conf={k: self.config[k] for k in ('FSDB_PATH', 'ES_HOSTS', 'ES_INDEXNAME')})
+        self.archivant = Archivant(conf={k: self.config[k] for k in ('TESTING', 'FSDB_PATH', 'ES_HOSTS', 'ES_INDEXNAME')})
         self.presetManager = PresetManager(self.config['PRESET_PATHS'])
 
         if self.config['USERS_DATABASE']:


### PR DESCRIPTION
I've start working on this because I've noticed that some tests that deal with scored results
were acting in a strange way. They provide different outcome at every runs.

I've discovered that with few data and multiple shards the scored queries get unreliable. For additional details
you can look at the ES official docs:
https://www.elastic.co/guide/en/elasticsearch/guide/1.x/relevance-is-broken.html

To solve this issue I've introduced a testing mode at libreantdb layer.
You can enable this mode using the `testing` param of the `DB.__init__()` function.

So if we are running testing mode we are not interested neither in es replicas nor in es shards.
Thus when testing mode is enabled, libreantdb will create and index with just one shard and no replicas.

There is also a nice side effect while using testing mode, in fact a simple benchmark had shown that these changes speed up the tests execution time by about 18%.