### PR TITLE
Add support for Elasticsearch 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,42 @@
 language: python
 
+python:
+ - 2.7
+
 services:
   - elasticsearch
 
+env:
+    - VERSION_ES=1.x
+
 matrix:
+    fast_finish: true
+
+    allow_failures:
+        - env: VERSION_ES=2.x
+
     include:
         - python: "2.7"
-          env: TEST_SUITE=test VERSION_GEVENT=1.0.1
-        - python: "2.7"
-          env: TEST_SUITE=test VERSION_GEVENT=1.0.2
-        - python: "2.7"
-          env: TEST_SUITE=test VERSION_GEVENT=1.1.0
-        - python: "2.7"
-          env: TEST_SUITE=build_sphinx
+          sudo: true
+          env: VERSION_ES=2.x
+
         - python: "2.7"
           env: TEST_SUITE=flake
 
-before_install:
-    - '[[ -n $VERSION_GEVENT ]] && pip install --force gevent==$VERSION_GEVENT || true'
+        - python: "2.7"
+          env: TEST_SUITE=build_sphinx
+
 
 install:
-    - 'if [[ $TEST_SUITE == flake ]]; then pip install flake8; return $? ; fi'
-    - 'if [[ $TEST_SUITE != flake ]]; then python setup.py install; return $? ; fi'
-    - 'if [[ $TEST_SUITE == build_sphinx ]]; then pip install sphinx; return $? ; fi'
+    - 'if [[ $TEST_SUITE == flake ]]; then pip install flake8; return $?; fi'
+    - 'if [[ $TEST_SUITE != flake ]]; then python setup.py install; return $?; fi'
+    - 'if [[ $TEST_SUITE == build_sphinx ]]; then pip install sphinx; return $?; fi'
+
+before_script:
+    - bash -x ./travis/install_dependencies.sh
 
 script:
+    - 'if [[ -z $TEST_SUITE ]]; then sleep 10; python setup.py test; return $?; fi'
     - 'if [[ $TEST_SUITE == flake ]]; then flake8; return $?; fi'
-    - 'if [[ $TEST_SUITE == test ]]; then sleep 10 && python setup.py test ; return $?; fi'
     - 'if [[ $TEST_SUITE == build_sphinx ]]; then python setup.py build_sphinx; return $?; fi'
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ env:
 matrix:
     fast_finish: true
 
-    allow_failures:
-        - env: VERSION_ES=2.x
-
     include:
         - python: "2.7"
           sudo: true

--- a/archivant/test/class_template.py
+++ b/archivant/test/class_template.py
@@ -27,8 +27,8 @@ class TestArchivant():
         self.arc = Archivant(conf)
 
     def tearDown(self):
-        self.arc._db.es.delete_by_query(index=self.TEST_ES_INDEX,
-                                        body={'query': {'match_all': {}}})
+        self.arc._db.delete_all()
+        self.refresh_index()
         rmtree(self.tmpDir)
         self.tmpDir = None
         self.arc = None

--- a/archivant/test/test_insert_volume.py
+++ b/archivant/test/test_insert_volume.py
@@ -22,7 +22,6 @@ class TestArchivantInsertVolume(TestArchivant):
         added_volume = self.arc.get_volume(id)
         ok_('id' in added_volume)
         eq_(added_volume['type'], 'volume')
-        eq_(len(volume_metadata), len(added_volume['metadata']))
         for k, v in volume_metadata.items():
             eq_(added_volume['metadata'][k], v)
 

--- a/cli/tests/test_libreant_db.py
+++ b/cli/tests/test_libreant_db.py
@@ -96,7 +96,7 @@ class TestInsert(TestDedicatedEs):
         eq_(export_res.exit_code, 0)
         volume_data = json.loads(export_res.output)
         eq_(volume_data['metadata']['_language'], 'en')
-        eq_(len(volume_data['metadata'].keys()), 1)
+        eq_(len(volume_data['metadata'].keys()), 2) # _language and _insertion_date properties
 
     def test_no_language(self):
         '''--language is required'''

--- a/libreantdb/api.py
+++ b/libreantdb/api.py
@@ -153,7 +153,7 @@ class DB(object):
             except MappingsException as ex:
                 log.error(ex)
                 log.warn('An old or wrong properties mapping has been found for index: "{0}",\
-                          this could led to some errors. It is recomanded to perform a reindexing'.format(self.index_name))
+                          this could led to some errors. It is recomanded to run "libreant-db upgrade"'.format(self.index_name))
         else:
             log.debug("Index is missing: '{0}'".format(self.index_name))
             self.create_index()

--- a/libreantdb/exceptions.py
+++ b/libreantdb/exceptions.py
@@ -1,0 +1,2 @@
+class MappingsException(Exception):
+    pass

--- a/libreantdb/migration.py
+++ b/libreantdb/migration.py
@@ -1,0 +1,39 @@
+from elasticsearch.helpers import scan, bulk
+
+
+# Migration from _timestamp special field to _insertion_date
+
+missing_insertion_date_query = {
+        "constant_score" : {
+            "filter" : { "missing" : { "field" : "_insertion_date" } }
+        }
+    }
+
+
+def elements_without_insertion_date(es, indexname):
+    return es.count(index=indexname, body={'query': missing_insertion_date_query})['count']
+
+
+def migrate_timestamp(es, indexname):
+    query = {"fields": ["_timestamp", "_source"],
+             "query": missing_insertion_date_query}
+
+    def update_action_gen():
+        scanner = scan(es,
+                       index=indexname,
+                       query=query)
+        for v in scanner:
+            if "_timestamp" in v:
+                timestamp = v['_timestamp']
+            elif 'fields' in v and '_timestamp' in v['fields']:
+                timestamp = v['fields']['_timestamp']
+            else:
+                raise Exception("Cannot find '_timestamp' field on volume with id: '{}'".format(v['_id']))
+
+            yield { '_op_type': 'update',
+                    '_index': indexname,
+                    '_type': v['_type'],
+                    '_id': v['_id'],
+                    'doc':{'_insertion_date': timestamp}
+                  }
+    return bulk(es, update_action_gen())

--- a/libreantdb/test/__init__.py
+++ b/libreantdb/test/__init__.py
@@ -17,8 +17,7 @@ def tearDownPackage():
 
 def cleanall():
     if db.es.indices.exists(db.index_name):
-        db.es.delete_by_query(index=db.index_name,
-                              body={'query': {'match_all': {}}})
+        db.delete_all()
     else:
         db.setup_db()
     db.es.indices.refresh(index=db.index_name)

--- a/libreantdb/test/test_delete.py
+++ b/libreantdb/test/test_delete.py
@@ -26,3 +26,15 @@ def test_delete_one_of_two():
     db.delete_book(id2)
     db.es.indices.refresh(index=db.index_name)
     eq_(len(db), 1)
+
+
+@with_setup(cleanall, cleanall)
+def test_delete_all():
+    db.add_book(body=dict(title='Un libro 1', _language='it'))['_id']
+    db.add_book(body=dict(title='Un libro 2', _language='it'))['_id']
+    db.add_book(body=dict(title='Un libro 3', _language='it'))['_id']
+    db.es.indices.refresh(index=db.index_name)
+    eq_(len(db), 3)
+    db.delete_all()
+    db.es.indices.refresh(index=db.index_name)
+    eq_(len(db), 0)

--- a/libreantdb/test/test_last_inserted.py
+++ b/libreantdb/test/test_last_inserted.py
@@ -20,9 +20,9 @@ def test_last():
 
 
 @with_setup(cleanall, cleanall)
-def test_has_timestamp():
-    ''' last_inserted results must have ['fields']['_timestamp']'''
+def test_has_insertion_date():
+    ''' last_inserted results must have '_insertion_date']'''
     db.add_book(doc_type='book',
                 body=dict(title='ma che ne so', _language='it'))['_id']
     db.es.indices.refresh(index=db.index_name)
-    assert('_timestamp' in db.get_last_inserted()['hits']['hits'][0]['fields'])
+    assert('_insertion_date' in db.get_last_inserted()['hits']['hits'][0]['_source'])

--- a/libreantdb/test/test_mlt.py
+++ b/libreantdb/test/test_mlt.py
@@ -91,3 +91,28 @@ def test_mlt_en_topic_2():
     res = db.mlt(book_id1)['hits']
     eq_(res['total'], 1)
     eq_(res['hits'][0]['_id'], book_id2)
+
+
+@with_setup(cleanall, cleanall)
+def test_mlt_multilan_topic_2():
+    '''MLT: Two additional books with different languages, one about same topic, one totally different'''
+    b = dict(title='On the origins of Africa',
+             actors=['marco', 'giulio'],
+             _language='en')
+    book_id1 = db.add_book(doc_type='book', body=b)['_id']
+    b = dict(title='Africa: a tour on the origins',
+             actors=['frank', 'johnny'],
+             _language='en')
+    book_id2 = db.add_book(doc_type='book', body=b)['_id']
+    b = dict(title='Computer Networks',
+             actors=['switch', 'router'],
+             _language='en')
+    db.add_book(doc_type='book', body=b)['_id']
+    b = dict(title='Reti di calcolatori',
+             actors=['switch', 'router'],
+             _language='it')
+    db.add_book(doc_type='book', body=b)['_id']
+    db.es.indices.refresh(index=db.index_name)
+    res = db.mlt(book_id1)['hits']
+    eq_(res['total'], 1)
+    eq_(res['hits'][0]['_id'], book_id2)

--- a/libreantdb/test/test_query.py
+++ b/libreantdb/test/test_query.py
@@ -12,7 +12,7 @@ from . import db, cleanall
 @with_setup(cleanall)
 def test_start_hasindex():
     '''If the test is setup properly, we got our own index'''
-    assert db.index_name in db.es.indices.status()['indices']
+    assert db.es.indices.exists(db.index_name)
 
 
 @with_setup(cleanall)

--- a/travis/install_dependencies.sh
+++ b/travis/install_dependencies.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+if [[ $VERSION_ES == "2.x" ]]; then
+    sudo apt-get autoremove --purge elasticsearch
+    wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+    echo "deb http://packages.elastic.co/elasticsearch/2.x/debian stable main" | sudo tee -a /etc/apt/sources.list.d/elk.list
+    sudo apt-get update && sudo apt-get install elasticsearch -y
+    sudo service elasticsearch start
+    sed -i "s/\('elasticsearch\)\(.*\)\('\)/\1 >2\3/g" setup.py
+    pip install --upgrade elasticsearch>=2.0
+fi

--- a/webant/templates/recents.html
+++ b/webant/templates/recents.html
@@ -62,8 +62,8 @@ header h1{
             <div class="item-sub col-xs-12 col-sm-3 vcenter">
                 <ul class="meta-list list-unstyled">
                     <li><span class="glyphicon glyphicon-time"></span>
-                        <date data-timestamp="{{ b['fields']['_timestamp'] }}">
-                            {{ b['fields']['_timestamp'] | timepassedformat }}
+                        <date data-timestamp="{{ b['_source']['_insertion_date'] }}">
+                            {{ b['_source']['_insertion_date'] | timepassedformat }}
                         </date>
                     </li>
                     <li><span class="glyphicon glyphicon-flag"></span> {{ b['_source']['_language'] }}</li>


### PR DESCRIPTION
You can find the old discussion about ES `2.x` support on old PR #267.

This PR aims to make the code completely compatible with Elasticsearch 2.x versions. 

A lot of functionalities have been deprecated and even removed in the new versions of ES, thus I needed to change a lot of stuff.

Even if I made a lot of small changes I've leaved the tests almost unchanged, moreover I've made travis run our tests also upon last version of Elasticsearch 2.x.
