### PR TITLE
conf utils: check if input configuration is a dict

### DIFF
--- a/conf/config_utils.py
+++ b/conf/config_utils.py
@@ -10,12 +10,15 @@ def from_file(fname):
     try:
         with open(fname) as buf:
             conf = json.load(buf)
-            return conf
     except ValueError as ve:
-        log.error('Bad json format on conf file: "{0}"; {1}'.format(fname, str(ve)))
-        raise ve
+        raise Exception('Bad json format on configuration file: "{0}" [{1}]'.format(fname, str(ve)))
     except EnvironmentError as ee:
         raise Exception('Cannot read configuration file: {0} [{1}]'.format(fname, ee.strerror))
+
+    if not isinstance(conf, dict):
+        raise Exception('Bad format on configuration file: "{0}" [ dictionary object was expected, instead "{1}" was found]'.format(fname, type(conf).__name__))
+
+    return conf
 
 
 def from_envvar_file(envvar, environ=None):

--- a/conf/test/test_config.py
+++ b/conf/test/test_config.py
@@ -8,7 +8,7 @@ from tempfile import mkstemp
 import json
 import os
 
-from nose.tools import eq_, raises
+from nose.tools import eq_, raises, assert_raises_regexp
 
 from conf.config_utils import from_envvars, from_envvar_file
 
@@ -99,7 +99,6 @@ def test_file_notexist():
                      environ={'MYRC': '/tmp/notexist.webant.test'})
 
 
-@raises(ValueError)
 def test_file_wrong_format():
     '''if config file has bad json fomat an exception should be raised'''
     tempFd, tempPath = mkstemp(suffix='.json', prefix='webant_test',
@@ -108,8 +107,9 @@ def test_file_wrong_format():
         with os.fdopen(tempFd, 'w') as f:
             f.write('not in json format $%^&*(, ')
 
-        from_envvar_file('MYRC',
-                         environ={'MYRC': tempPath})
+        with assert_raises_regexp(Exception, r".*(B|b)ad json format.*"):
+            from_envvar_file('MYRC',
+                             environ={'MYRC': tempPath})
     finally:
         os.unlink(tempPath)
 


### PR DESCRIPTION
if the configuration is a valid JSON formatted file but it's not a
dictionary an exception is raised

fixes #283