### PR TITLE
Securing REST api

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ conf = dict(
           'flask-bootstrap',
           'Flask-Babel',
           'flask-script',
-          'Flask-Authbone >=0.2',
+          'Flask-Authbone >=0.2.2',
           'Flask <= 0.11.1',
           'opensearch',
           'Fsdb >= 0.3.3, <= 1.2.1',

--- a/webant/api/blueprint_api.py
+++ b/webant/api/blueprint_api.py
@@ -3,6 +3,7 @@ from webant.util import add_routes
 from util import ApiError
 from archivant_api import routes as archivantRoutes
 from users_api import routes as usersRoutes
+from authbone.authorization import CapabilityMissingException
 
 
 def get_blueprint_api(archivant_routes=True,
@@ -28,6 +29,10 @@ def get_blueprint_api(archivant_routes=True,
     @api.route("/<path:invalid_path>", methods=['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS'])
     def apiNotFound(invalid_path):
         raise ApiError("invalid URI", 404)
+
+    @api.errorhandler(CapabilityMissingException)
+    def not_authorized_handler(error):
+        return apiErrorHandler(ApiError('Unauthorized Request', 403))
 
     @api.errorhandler(Exception)
     def exceptionHandler(e):

--- a/webant/api/users_api.py
+++ b/webant/api/users_api.py
@@ -3,6 +3,7 @@ from util import ApiError, make_success_response, on_json_load_error
 from flask import request, url_for, jsonify
 import users.api
 from users import Action
+from flask import current_app
 
 routes = []
 route = routes_collector(routes)
@@ -10,6 +11,7 @@ route = routes_collector(routes)
 
 @route('/users/<int:userID>', methods=['GET'])
 def get_user(userID):
+    current_app.authz.perform_authorization(('/users/{}'.format(userID), Action.READ))
     try:
         u = users.api.get_user(id=userID)
     except users.api.NotFoundException, e:
@@ -19,6 +21,7 @@ def get_user(userID):
 
 @route('/users/<int:userID>', methods=['DELETE'])
 def delete_user(userID):
+    current_app.authz.perform_authorization(('/users/{}'.format(userID), Action.DELETE))
     try:
         users.api.delete_user(id=userID)
     except users.api.NotFoundException, e:
@@ -28,12 +31,14 @@ def delete_user(userID):
 
 @route('/users/', methods=['GET'])
 def get_users():
+    current_app.authz.perform_authorization(('/users/*', Action.READ))
     usrs = [{'id': u.id, 'name': u.name} for u in users.api.get_users()]
     return jsonify({'data': usrs})
 
 
 @route('/users/', methods=['POST'])
 def add_user():
+    current_app.authz.perform_authorization(('/users/*', Action.CREATE))
     request.on_json_loading_failed = on_json_load_error
     userData = request.get_json()
     # the next two lines should be removed when Flask version is >= 1.0
@@ -58,6 +63,7 @@ def add_user():
 
 @route('/users/<int:userID>', methods=['PATCH'])
 def update_user(userID):
+    current_app.authz.perform_authorization(('/users/{}'.format(userID), Action.UPDATE))
     request.on_json_loading_failed = on_json_load_error
     userData = request.get_json()
     # the next two lines should be removed when Flask version is >= 1.0
@@ -72,6 +78,7 @@ def update_user(userID):
 
 @route('/groups/<int:groupID>', methods=['GET'])
 def get_group(groupID):
+    current_app.authz.perform_authorization(('/groups/{}'.format(groupID), Action.READ))
     try:
         g = users.api.get_group(id=groupID)
     except users.api.NotFoundException, e:
@@ -81,6 +88,7 @@ def get_group(groupID):
 
 @route('/groups/<int:groupID>', methods=['DELETE'])
 def delete_group(groupID):
+    current_app.authz.perform_authorization(('/groups/{}'.format(groupID), Action.DELETE))
     try:
         users.api.delete_group(id=groupID)
     except users.api.NotFoundException, e:
@@ -90,12 +98,14 @@ def delete_group(groupID):
 
 @route('/groups/', methods=['GET'])
 def get_groups():
+    current_app.authz.perform_authorization(('/groups/*', Action.READ))
     groups = [ {'id': g.id, 'name': g.name } for g in users.api.get_groups() ]
     return jsonify({'data': groups})
 
 
 @route('/groups/', methods=['POST'])
 def add_group():
+    current_app.authz.perform_authorization(('/groups/*', Action.CREATE))
     request.on_json_loading_failed = on_json_load_error
     groupData = request.get_json()
     # the next two lines should be removed when Flask version is >= 1.0
@@ -117,6 +127,7 @@ def add_group():
 
 @route('/groups/<int:groupID>', methods=['PATCH'])
 def update_group(groupID):
+    current_app.authz.perform_authorization(('/groups/{}'.format(groupID), Action.UPDATE))
     request.on_json_loading_failed = on_json_load_error
     groupData = request.get_json()
     # the next two lines should be removed when Flask version is >= 1.0
@@ -131,6 +142,7 @@ def update_group(groupID):
 
 @route('/groups/<int:groupID>/users/<int:userID>', methods=['PUT'])
 def add_user_to_group(groupID, userID):
+    current_app.authz.perform_authorization(('/groups/{}/users/{}'.format(groupID, userID), Action.CREATE))
     try:
         users.api.add_user_to_group(userID, groupID)
     except users.api.NotFoundException, e:
@@ -140,6 +152,7 @@ def add_user_to_group(groupID, userID):
 
 @route('/groups/<int:groupID>/users/<int:userID>', methods=['DELETE'])
 def delete_user_from_group(groupID, userID):
+    current_app.authz.perform_authorization(('/groups/{}/users/{}'.format(groupID, userID), Action.DELETE))
     try:
         users.api.remove_user_from_group(userID, groupID)
     except users.api.NotFoundException, e:
@@ -149,6 +162,7 @@ def delete_user_from_group(groupID, userID):
 
 @route('/groups/<int:groupID>/users/', methods=['GET'])
 def get_users_in_group(groupID):
+    current_app.authz.perform_authorization(('/groups/{}/users/*'.format(groupID), Action.READ))
     try:
         us = [{'id': u.id} for u in users.api.get_users_in_group(groupID)]
     except users.api.NotFoundException, e:
@@ -158,6 +172,7 @@ def get_users_in_group(groupID):
 
 @route('/users/<int:userID>/groups/', methods=['GET'])
 def get_groups_of_user(userID):
+    current_app.authz.perform_authorization(('/users/{}/groups/*'.format(userID), Action.READ))
     try:
         groups = [{'id': g.id} for g in users.api.get_groups_of_user(userID)]
     except users.api.NotFoundException, e:
@@ -167,12 +182,14 @@ def get_groups_of_user(userID):
 
 @route('/capabilities/', methods=['GET'])
 def get_capabilities():
+    current_app.authz.perform_authorization(('/capabilities/*', Action.READ))
     capabilities = [ c.to_dict() for c in users.api.get_capabilities()]
     return jsonify({'data': capabilities})
 
 
 @route('/capabilities/<int:capID>', methods=['GET'])
 def get_capability(capID):
+    current_app.authz.perform_authorization(('/capabilities/{}'.format(capID), Action.READ))
     try:
         cap = users.api.get_capability(capID)
     except users.api.NotFoundException, e:
@@ -182,6 +199,7 @@ def get_capability(capID):
 
 @route('/capabilities/<int:capID>', methods=['DELETE'])
 def delete_capability(capID):
+    current_app.authz.perform_authorization(('/capabilities/{}'.format(capID), Action.DELETE))
     try:
         users.api.delete_capability(capID)
     except users.api.NotFoundException, e:
@@ -191,6 +209,7 @@ def delete_capability(capID):
 
 @route('/capabilities/', methods=['POST'])
 def add_capability():
+    current_app.authz.perform_authorization(('/capabilities/*', Action.CREATE))
     request.on_json_loading_failed = on_json_load_error
     capData = request.get_json()
     # the next two lines should be removed when Flask version is >= 1.0
@@ -212,6 +231,7 @@ def add_capability():
 
 @route('/capabilities/<int:capID>', methods=['PATCH'])
 def update_capability(capID):
+    current_app.authz.perform_authorization(('/capabilities/{}'.format(capID), Action.UPDATE))
     request.on_json_loading_failed = on_json_load_error
     capData = request.get_json()
     # the next two lines should be removed when Flask version is >= 1.0
@@ -228,6 +248,7 @@ def update_capability(capID):
 
 @route('/groups/<int:groupID>/capabilities/<int:capID>', methods=['PUT'])
 def add_capability_to_group(groupID, capID):
+    current_app.authz.perform_authorization(('/groups/{}/capabilities/{}'.format(groupID, capID), Action.CREATE))
     try:
         users.api.add_capability_to_group(capID, groupID)
     except users.api.NotFoundException, e:
@@ -237,6 +258,7 @@ def add_capability_to_group(groupID, capID):
 
 @route('/groups/<int:groupID>/capabilities/<int:capID>', methods=['DELETE'])
 def delete_capability_from_group(groupID, capID):
+    current_app.authz.perform_authorization(('/groups/{}/capabilities/{}'.format(groupID, capID), Action.DELETE))
     try:
         users.api.remove_capability_from_group(capID, groupID)
     except users.api.NotFoundException, e:
@@ -246,6 +268,7 @@ def delete_capability_from_group(groupID, capID):
 
 @route('/groups/<int:groupID>/capabilities/', methods=['GET'])
 def get_capabilities_of_group(groupID):
+    current_app.authz.perform_authorization(('/groups/{}/capabilities/*'.format(groupID), Action.READ))
     try:
         caps = [ cap.to_dict() for cap in users.api.get_capabilities_of_group(groupID)]
     except users.api.NotFoundException, e:
@@ -255,6 +278,7 @@ def get_capabilities_of_group(groupID):
 
 @route('/capabilities/<int:capID>/groups/', methods=['GET'])
 def get_groups_with_capability(capID):
+    current_app.authz.perform_authorization(('/capabilities/{}/groups/*'.format(capID), Action.READ))
     try:
         groups = [{'id': g.id} for g in users.api.get_groups_with_capability(capID)]
     except users.api.NotFoundException, e:

--- a/webant/auth.py
+++ b/webant/auth.py
@@ -1,0 +1,53 @@
+from flask import session
+from users.api import get_user, get_anonymous_user, NotFoundException
+from authbone import Authenticator, Authorizator
+
+
+class AuthtFromSession(Authenticator):
+
+    USERID_KEY = 'user_id'
+
+    def login(self, userID):
+        session[self.USERID_KEY] = userID
+
+    def logout(self):
+        session.pop(self.USERID_KEY)
+
+    def is_logged_in(self):
+        return self.USERID_KEY in session
+
+    def auth_data_getter(self):
+        return session.get(self.USERID_KEY, None)
+
+    def authenticate(self, userID):
+        try:
+            return get_user(id=userID)
+        except NotFoundException:
+            return None
+
+
+class AuthtFromSessionAnon(AuthtFromSession):
+
+    def bad_auth_data_callback(self):
+        self.identity_elaborator(get_anonymous_user())
+
+    def not_authenticated_callback(self):
+        self.identity_elaborator(get_anonymous_user())
+
+
+class AuthzFromSession(Authorizator):
+
+    def check_capability(self, identity, capability):
+        return identity.can(capability[0], capability[1])
+
+
+class TransparentAutht(AuthtFromSession):
+
+    def perform_authentication(self, *args, **kwargs):
+        pass
+
+
+class TransparentAuthz(AuthzFromSession):
+
+    def perform_authorization(self, *args, **kwargs):
+        pass

--- a/webant/test/__init__.py
+++ b/webant/test/__init__.py
@@ -37,3 +37,13 @@ class WebantUsersTestCase(WebantTestCase):
              'PWD_ROUNDS': 1,
              'USERS_DATABASE': 'sqlite:///:memory:'
         })
+
+    def login(self, username, password):
+        return self.wtc.post('/login',
+                             data=dict(
+                                username=username,
+                                password=password),
+                             follow_redirects=True)
+
+    def logout(self):
+        return self.wtc.get('/logout', follow_redirects=True)

--- a/webant/test/__init__.py
+++ b/webant/test/__init__.py
@@ -21,11 +21,11 @@ class WebantTestCase(unittest.TestCase):
         es = Elasticsearch()
         es.indices.delete(cls.conf['ES_INDEXNAME'], ignore=[404])
 
-    @property
-    def wtc(self):
-        if not getattr(self, '_wtc', None):
-            self._wtc = create_app(self.conf).test_client()
-        return self._wtc
+    def setUp(self):
+        self.wtc = create_app(self.conf).test_client()
+
+    def tearDown(self):
+        del self.wtc
 
 
 class WebantUsersTestCase(WebantTestCase):

--- a/webant/test/api/__init__.py
+++ b/webant/test/api/__init__.py
@@ -35,6 +35,13 @@ class WebantTestApiCase(WebantUsersTestCase):
         return loads(res.data)['data']['id']
 
 
+class WebantTestApiAdminCase(WebantTestApiCase):
+
+    def setUp(self):
+        super(WebantTestApiCase, self).setUp()
+        self.login('admin', 'admin')
+
+
 class ApiClientError(Exception):
 
     def __init__(self, res):

--- a/webant/test/api/test_api_authlayer.py
+++ b/webant/test/api/test_api_authlayer.py
@@ -1,0 +1,26 @@
+from webant.test.api import WebantTestApiCase, ApiClientError
+import users
+from nose.tools import eq_
+
+
+class TestApiAuthLayer(WebantTestApiCase):
+
+    def test_add_user_as_anon(self):
+        ''' Calling an api without capability should return an 401 Unauthorized response'''
+        with self.assertRaises(ApiClientError) as ace:
+            self.add_user({'name':'testName', 'password': 'testPassword'})
+        eq_(ace.exception.res.status_code, 403)
+
+    def test_add_user_with_capability(self):
+        usrName = 'testUsr'
+        usrPwd = 'testPwd'
+        usrID = users.api.add_user(usrName, usrPwd)
+        capID = users.api.add_capability('/users/*', users.Action.CREATE)
+        groupID = users.api.add_group('TestGroup')
+
+        users.api.add_user_to_group(usrID, groupID)
+        users.api.add_capability_to_group(capID, groupID)
+
+        logRes = self.login(usrName, usrPwd)
+        eq_(logRes.status_code, 200)
+        self.add_user({'name':'testName', 'password': 'testPassword'})

--- a/webant/test/api/test_api_capabilities.py
+++ b/webant/test/api/test_api_capabilities.py
@@ -1,9 +1,9 @@
-from webant.test.api import WebantTestApiCase, ApiClientError
+from webant.test.api import WebantTestApiAdminCase, ApiClientError
 from nose.tools import eq_
 from flask.json import loads, dumps
 
 
-class TestApiCapabilities(WebantTestApiCase):
+class TestApiCapabilities(WebantTestApiAdminCase):
 
     def test_get_capability_not_exist(self):
         r = self.wtc.get(self.CAP_URI + 'a1s2d')

--- a/webant/test/api/test_api_groups.py
+++ b/webant/test/api/test_api_groups.py
@@ -1,9 +1,9 @@
-from webant.test.api import WebantTestApiCase, ApiClientError
+from webant.test.api import WebantTestApiAdminCase, ApiClientError
 from nose.tools import eq_
 from flask.json import loads, dumps
 
 
-class TestApiGroups(WebantTestApiCase):
+class TestApiGroups(WebantTestApiAdminCase):
 
     def test_get_group_not_exist(self):
         r = self.wtc.get(self.GRP_URI + 'a1s2d')

--- a/webant/test/api/test_api_users.py
+++ b/webant/test/api/test_api_users.py
@@ -1,9 +1,9 @@
-from webant.test.api import WebantTestApiCase, ApiClientError
+from webant.test.api import WebantTestApiAdminCase, ApiClientError
 from nose.tools import eq_
 from flask.json import dumps, loads
 
 
-class TestApiUsers(WebantTestApiCase):
+class TestApiUsers(WebantTestApiAdminCase):
 
     def test_add_user(self):
         self.add_user({'name':'testName', 'password': 'testPassword'})

--- a/webant/util.py
+++ b/webant/util.py
@@ -1,7 +1,5 @@
 import functools
-from flask import send_file, session
-from authbone import Authenticator, Authorizator
-from users.api import get_user, get_anonymous_user, NotFoundException
+from flask import send_file
 
 
 def memoize(obj):
@@ -128,50 +126,3 @@ def get_centered_pagination(current, total, visible=5):
                 current = current,
                 last=last,
                 next = current+1 if(current < total) else None)
-
-
-class AuthtFromSession(Authenticator):
-
-    USERID_KEY = 'user_id'
-
-    def login(self, userID):
-        session[self.USERID_KEY] = userID
-
-    def logout(self):
-        session.pop(self.USERID_KEY)
-
-    def is_logged_in(self):
-        return self.USERID_KEY in session
-
-    def auth_data_getter(self):
-        return session.get(self.USERID_KEY, None)
-
-    def authenticate(self, userID):
-        try:
-            return get_user(id=userID)
-        except NotFoundException:
-            return None
-
-    def bad_auth_data_callback(self):
-        self.identity_elaborator(get_anonymous_user())
-
-    def not_authenticated_callback(self):
-        self.identity_elaborator(get_anonymous_user())
-
-
-class AuthzFromSession(Authorizator):
-
-    def check_capability(self, identity, capability):
-        return identity.can(capability[0], capability[1])
-
-
-class TransparentAutht(AuthtFromSession):
-
-    def perform_authentication(self, *args, **kwargs):
-        pass
-
-
-class TransparentAuthz(AuthzFromSession):
-
-    def perform_authorization(self, *args, **kwargs):
-        pass

--- a/webant/webant.py
+++ b/webant/webant.py
@@ -19,7 +19,8 @@ from agherant import agherant
 from api.blueprint_api import get_blueprint_api
 from webserver_utils import gevent_run
 import users
-import util
+from . import util
+from . import auth
 from authbone.authorization import CapabilityMissingException
 
 
@@ -82,11 +83,11 @@ class LibreantViewApp(LibreantCoreApp):
         self.babel = Babel(self)
         self.available_translations = [l.language for l in self.babel.list_translations()]
         if self.users_enabled:
-            self.autht = util.AuthtFromSession()
-            self.authz = util.AuthzFromSession(authenticator=self.autht)
+            self.autht = auth.AuthtFromSessionAnon()
+            self.authz = auth.AuthzFromSession(authenticator=self.autht)
         else:
-            self.autht = util.TransparentAutht()
-            self.authz = util.TransparentAuthz()
+            self.autht = auth.TransparentAutht()
+            self.authz = auth.TransparentAuthz()
 
 
 def create_app(conf={}):


### PR DESCRIPTION
This PR should fix #287.

I've added the authentication layer also to all the REST endpoints. I've implemented the simplest approach: the authentication method is the same used for the rest of the libreant web ui. This means that in order to use a restricted REST endpoint you should have been authenticated through the `/login` page.

As we've already discussed with @boyska in #287 this is doesn't respect the REST paradigm at all, but it works and it should be enough to fix the security issue.

We had a lot of old test functions that were used to test the REST api, in order to make them continue to work I've managed to execute them as the admin user that has all the capabilities granted by default.

Probably we need some more tests against the authorization layer, I really hope that some contribution for that will arrive.