### PR TITLE
update flask dependecy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ conf = dict(
           'Flask-Babel',
           'flask-script',
           'Flask-Authbone >=0.2',
-          'Flask',
+          'Flask <= 0.11.1',
           'opensearch',
           'Fsdb >= 0.3.3, <= 1.2.1',
           'click',

--- a/webant/agherant_standalone.py
+++ b/webant/agherant_standalone.py
@@ -1,6 +1,6 @@
 from flask import Flask, request
 from flask_bootstrap import Bootstrap
-from flask.ext.babel import Babel
+from flask_babel import Babel
 
 import agherant
 from webserver_utils import gevent_run

--- a/webant/webant.py
+++ b/webant/webant.py
@@ -5,7 +5,7 @@ from flask import Flask, render_template, request, Response, redirect, url_for
 from werkzeug import secure_filename
 from flask_bootstrap import Bootstrap
 from elasticsearch import exceptions as es_exceptions
-from flask.ext.babel import Babel, gettext
+from flask_babel import Babel, gettext
 from babel.dates import format_timedelta
 from datetime import datetime
 from logging import getLogger


### PR DESCRIPTION
some minor changes to support the new flask version 0.11.1

importing stuff from `flask.ext` was deprecated and we were using it
only for babel

fixes #297