### PR TITLE
Debian stable travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
 install:
     - 'pip install -U pip wheel'
     - 'if [[ $TEST_SUITE == flake ]]; then pip install flake8; return $?; fi'
-    - 'if [[ $TEST_SUITE != flake ]]; then python setup.py install; return $?; fi'
+    - 'if [[ $TEST_SUITE != flake ]]; then pip install .; return $?; fi'
     - 'if [[ $TEST_SUITE == build_sphinx ]]; then pip install sphinx; return $?; fi'
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ matrix:
         - python: "2.7"
           env: TEST_SUITE=flake
 
+        # Debian Jessie
+        - python: "2.7"
+          env:
+              - EXTRA_INSTALLS="gevent==1.0.1 flask==0.10.1"
+              - VERSION_ES=1.x
+
         - python: "2.7"
           env: TEST_SUITE=build_sphinx
 
@@ -29,6 +35,7 @@ install:
     - 'if [[ $TEST_SUITE == flake ]]; then pip install flake8; return $?; fi'
     - 'if [[ $TEST_SUITE != flake ]]; then pip install .; return $?; fi'
     - 'if [[ $TEST_SUITE == build_sphinx ]]; then pip install sphinx; return $?; fi'
+    - 'if [[ -n "$EXTRA_INSTALLS" ]]; then pip install $EXTRA_INSTALLS; return $?; fi'
 
 before_script:
     - bash -x ./travis/install_dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
 
 
 install:
+    - 'pip install -U pip wheel'
     - 'if [[ $TEST_SUITE == flake ]]; then pip install flake8; return $?; fi'
     - 'if [[ $TEST_SUITE != flake ]]; then python setup.py install; return $?; fi'
     - 'if [[ $TEST_SUITE == build_sphinx ]]; then pip install sphinx; return $?; fi'
@@ -37,3 +38,4 @@ script:
     - 'if [[ $TEST_SUITE == flake ]]; then flake8; return $?; fi'
     - 'if [[ $TEST_SUITE == build_sphinx ]]; then python setup.py build_sphinx; return $?; fi'
 
+cache: pip


### PR DESCRIPTION
This pull requests adds version specification that matches the versions in debian jessie (currently stable).

Since this was adding so much time to the build (`gevent` was being built two times) I finally (and cleanly) implemented caching and wheel support, so that the elapsed time is now shorter than before. See the first two commits for cache (yes, the second one is important).

This is related to #299 