### PR TITLE
Fixes to docs for v0.5

### DIFF
--- a/doc/source/sysadmin.rst
+++ b/doc/source/sysadmin.rst
@@ -80,7 +80,11 @@ Step 2: upgrade elasticsearch
 
 Just apply the steps in :ref:`sys-installation` section as if it was a brand new installation.
 
-If you are using archlinux, you must remove the ``IgnorePkg elasticsearch`` line in ``/etc/pacman.conf`` *before* trying to upgrade.
+.. note::
+
+    If you are using archlinux, you've probably made pacman ignore elasticsearch package updates.
+    In order to install the new elasticsearch version you must remove the ``IgnorePkg elasticsearch`` line in ``/etc/pacman.conf``
+    *before* trying to upgrade.
 
 Step 3: upgrade DB contents
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/sysadmin.rst
+++ b/doc/source/sysadmin.rst
@@ -23,11 +23,11 @@ Add elasticsearch repos in /etc/apt/sources.list.d/elasticsearch.list::
     echo "deb http://packages.elasticsearch.org/elasticsearch/2.x/debian stable main" | sudo tee /etc/apt/sources.list.d/elasticsearch.list
 
 Install requirements::
-    
+
     sudo apt-get update && sudo apt-get install python2.7 gcc python2.7-dev python-virtualenv openjdk-7-jre-headless elasticsearch
 
 .. note::
-    
+
     if you have problem installing elasticsearch try to follow the `official installation guide`_
 
 .. _official installation guide: http://www.elastic.co/guide/en/elasticsearch/reference/current/setup-repositories.html
@@ -47,7 +47,7 @@ Create a virtual env::
     virtualenv -p /usr/bin/python2 ve
 
 Install libreant and all python dependencies::
-    
+
     ./ve/bin/pip install libreant
 
 Upgrading
@@ -112,20 +112,20 @@ Start elasticsearch service::
 .. note::
 
     If you want to automatically start elasticsearch during bootup::
-        
+
         sudo update-rc.d elasticsearch defaults 95 10
 
 Arch / Debian jessie
 ~~~~~~~~~~~~~~~~~~~~
 
 Start elasticsearch service::
-    
+
     sudo systemctl start elasticsearch
 
 .. note::
 
     If you want to automatically start elasticsearch during bootup::
-        
+
         sudo systemctl enable elasticsearch
 
 

--- a/doc/source/sysadmin.rst
+++ b/doc/source/sysadmin.rst
@@ -62,10 +62,10 @@ And restart your instance (see the :ref:`sys-execution` section).
 Some versions, however, could need additional actions. We will list them all in
 this section.
 
-From 0.4 to 0.5
-^^^^^^^^^^^^^^^
+Upgrade to version 0.5
+^^^^^^^^^^^^^^^^^^^^^^
 
-libreant now supports elasticsearch2. If you were already using libreant0.4, you were using libreant 1.x.
+libreant now supports elasticsearch 2. If you were already using libreant 0.4, you were using elasticsearch 1.x.
 You *can* continue using it if you want. The standard upgrade procedure is enough to have everything working.
 However, we suggest you to upgrade to elasticsearch2 sooner or later.
 


### PR DESCRIPTION
- Some typo fixes.
- Enhancement to the upgrade note under arch linux
- Changed title to the `from v0.4 to v0.5` section into `Upgrade to v0.5`