### PR TITLE
fixed peewee version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ conf = dict(
           'opensearch',
           'Fsdb >= 0.3.3, <= 1.2.1',
           'click',
-          'peewee',
+          'peewee <= 2.8.1',
           'passlib >=1.6, <1.7' # version 1.7 will drop python2 suport
         ],
         package_data = {


### PR DESCRIPTION
We have some problems with peewee version `2.8.2` (issue #307)

Until these problems will be fixed we need to be sure to
not use the new vesion.

new constraint: peewee <= 2.8.1