### PR TITLE
add changelog to documentation

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../../CHANGELOG.rst

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,6 +18,7 @@ Contents:
    documentation
    developer
    api/modules
+   changelog
 
 
 


### PR DESCRIPTION
This very simple patch will include the already in-place `CHANGELOG.rst` inside sphinx documentation