### PR TITLE
remove unneeded dep to flask-script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,6 @@ conf = dict(
           'elasticsearch >=1, <2',
           'flask-bootstrap',
           'Flask-Babel',
-          'flask-script',
           'Flask-Authbone >=0.2.2',
           'Flask <= 0.11.1',
           'opensearch',


### PR DESCRIPTION
It's a leftover from when all the logic was flask-based. We changed the approach long time ago (4afb8495)
