### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,19 @@ matrix:
                   sources:
                       - elasticsearch-2.x
                   packages:
-                      - elasticsearch
+                      - elasticsearch=2.4.6
 
         # Debian Jessie (backports)
         - python: "2.7"
           env:
               - EXTRA_INSTALLS="gevent==1.0.1 flask==0.10.1"
-              - ES_VERSION=1.6
+              - ES_VERSION=1.7
           addons:
               apt:
                   sources:
-                      - elasticsearch-1.6
+                      - elasticsearch-1.7
                   packages:
-                      - elasticsearch
+                      - elasticsearch=1.7.5
 
         - python: "2.7"
           env: TEST_SUITE=flake

--- a/archivant/archivant.py
+++ b/archivant/archivant.py
@@ -232,7 +232,7 @@ class Archivant():
                 rawAttachment = self._assemble_attachment(a['file'], a)
                 rawVolume['_source']['_attachments'].append(rawAttachment)
                 attsID.append(rawAttachment['id'])
-            except:
+            except Exception:
                 log.exception("Error while elaborating attachments array at index: {}".format(index))
                 raise
         self._db.modify_book(volumeID, rawVolume['_source'], version=rawVolume['_version'])
@@ -281,7 +281,7 @@ class Archivant():
             try:
                 attData = self._assemble_attachment(a['file'], a)
                 attsData.append(attData)
-            except:
+            except Exception:
                 log.exception("Error while elaborating attachments array at index: {}".format(index))
                 raise
         volume['_attachments'] = attsData

--- a/cli/agherant.py
+++ b/cli/agherant.py
@@ -39,5 +39,6 @@ def agherant(settings, debug, port, address, agherant_descriptions):
             click.secho(str(e), fg='yellow', err=True)
             exit(1)
 
+
 if __name__ == '__main__':
     agherant()

--- a/cli/libreant_db.py
+++ b/cli/libreant_db.py
@@ -185,13 +185,13 @@ def export_all(pretty):
 
 @libreant_db.command(name='attach', help='adds an attachment to an existing volume')
 @click.argument('volumeid')
-@click.option('-f', 'filepath', type=click.Path(exists=True,resolve_path=True), multiple=True, help='the path of the attachment')
+@click.option('-f', 'filepath', type=click.Path(exists=True, resolve_path=True), multiple=True, help='the path of the attachment')
 @click.option('-t', '--notes', type=click.STRING, metavar='<string>', multiple=True, help='notes about the attachment')
 def append_file(volumeid, filepath, notes):
     attachments = attach_list(filepath, notes)
     try:
-        arc.insert_attachments(volumeid,attachments)
-    except:
+        arc.insert_attachments(volumeid, attachments)
+    except Exception:
         die('An upload error occurred in updating an attachment!', exit_code=4)
 
 
@@ -199,7 +199,7 @@ def append_file(volumeid, filepath, notes):
 @click.option('-l', '--language', type=click.STRING, required=True,
               help='specify the language of the volume')
 @click.option('-f', '--filepath',
-              type=click.Path(exists=True,resolve_path=True),
+              type=click.Path(exists=True, resolve_path=True),
               multiple=True, help='path to the attachment to be uploaded')
 @click.option('-t', '--notes', type=click.STRING, multiple=True,
               help='notes about the attachment '
@@ -232,13 +232,13 @@ def insert_volume(language, filepath, notes, metadata):
           libreant-db insert-volume -l en -f /path/book.epub --notes 'poor quality' -f /path/someother.epub --notes 'preprint'
 
     '''
-    meta = {"_language":language}
+    meta = {"_language": language}
     if metadata:
         meta.update(json.load(metadata))
     attachments = attach_list(filepath, notes)
     try:
-        out = arc.insert_volume(meta,attachments)
-    except:
+        out = arc.insert_volume(meta, attachments)
+    except Exception:
         die('An upload error have occurred!', exit_code=4)
     click.echo(out)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,5 @@ cover-package=libreantdb, webant, presets, archivant, users, utils, cli, conf
 
 [flake8]
 ignore=E1,E2,E5
+exclude=
+	msgfmt.py

--- a/users/models.py
+++ b/users/models.py
@@ -134,6 +134,7 @@ class Action(int):
         '''return the bitmask associated withe the given action name'''
         return 2**cls.ACTIONS.index(action.upper())
 
+
 for i, act in enumerate(Action.ACTIONS):
     setattr(Action, act.upper(), 2**i)
 

--- a/webant/agherant.py
+++ b/webant/agherant.py
@@ -57,6 +57,7 @@ def aggregate(descriptions, query):
     results.sort(key=lambda r: r.score, reverse=True)
     return results
 
+
 if __name__ == '__main__':
     description_list = ['http://127.0.0.1:5000/description.xml']
     results = aggregate(description_list, 'russia')

--- a/webant/agherant.py
+++ b/webant/agherant.py
@@ -50,7 +50,7 @@ def aggregate(descriptions, query):
         log.debug("Fetching description {}".format(url))
         try:
             clients.append(Client(url))
-        except:
+        except Exception:
             log.exception("Error retrieving description for '%s'" % url)
     results = map(lambda c: c.search(query), clients)
     results = list(chain(*results))

--- a/webant/agherant_standalone.py
+++ b/webant/agherant_standalone.py
@@ -24,5 +24,6 @@ def main(conf={}):
     app = create_app(conf)
     gevent_run(app)
 
+
 if __name__ == '__main__':
     main()

--- a/webant/webant.py
+++ b/webant/webant.py
@@ -370,5 +370,6 @@ def main(conf={}):
     app = create_app(conf)
     gevent_run(app)
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
There was two problems that didn't allow a correct completion of the travis build tests:

 - **New Flake8 errors**:
      The last version of Flake8 is raising new errors that remained undiscovered on previous version.
      Since we use Flake8 as mandatory check step for new PR we need to merge asap.
 - **Elasticsearch package version**:
      By default travis is installing the 5.5.0 version of ES thus if we don't force a specific previous version it wan't be installed cause a newer one is already there.


