### PR TITLE
added gemnasium.com badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,9 @@ LibreAnt
     :target: https://libreant.readthedocs.org/en/latest
     :alt: Documentation Status
 
+.. image:: https://gemnasium.com/badges/github.com/insomnia-lab/libreant.svg
+    :target: https://gemnasium.com/github.com/insomnia-lab/libreant
+    :alt: Dependency Status
 
 This is libreant: a software to manage both your ebooks and your physical books.
 Its approach is:


### PR DESCRIPTION
Thanks to the free service gemnasium.com we can easily monitor the dependencies version and receive security alerts. I've grant just the read permission thus only passive functionality of the service will be active (it won't generate automatic pull request for us)

https://gemnasium.com/github.com/insomnia-lab/libreant