### PR TITLE
FIX: new werkzeug is stricter about mimetypes

### DIFF
--- a/webant/webant.py
+++ b/webant/webant.py
@@ -135,7 +135,7 @@ def create_app(conf={}):
             books.append(src)
         format = requestedFormat(request,
                                  ['text/html',
-                                  'text/xml', 'application/rss+xml', 'opensearch'])
+                                  'text/xml', 'application/rss+xml'])
         if (not format) or (format is 'text/html'):
             return render_template('search.html',
                                    books=books,


### PR DESCRIPTION
not doing so results in in an exception raised on `/search`. werkzeug complains because `opensearch` has no `/` and thus is not a valid MIMEtype. this is correct. `opensearch` should have never been added to the list.